### PR TITLE
Refactor Error into ErrorKind

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,53 +1,115 @@
 //! Error types
 
+use failure::{Backtrace, Context, Fail};
+use std::fmt::{self, Display};
 use std::io;
 
 /// Error type
-#[derive(Clone, Eq, PartialEq, Debug, Fail)]
-pub enum Error {
-    /// Error in configuration file
-    #[fail(display = "{}", description)]
-    ConfigError {
-        /// Description of the error
-        description: String,
-    },
+#[derive(Debug)]
+pub struct Error {
+    /// Contextual information about the error
+    inner: Context<ErrorKind>,
 
-    /// Malformatted or otherwise invalid cryptographic key
-    #[fail(display = "{}", description)]
-    InvalidKey {
-        /// Description of the error
-        description: String,
-    },
-
-    /// Input/output error
-    #[fail(display = "{}", description)]
-    IoError {
-        /// Description of the error
-        description: String,
-    },
-
-    /// Signing operation failed
-    #[fail(display = "{}", description)]
-    SigningError {
-        /// Description of the error
-        description: String,
-    },
+    /// Optional description message
+    description: Option<String>,
 }
 
-impl From<io::Error> for Error {
-    fn from(other: io::Error) -> Self {
-        Error::IoError {
-            description: other.to_string(),
+impl Error {
+    /// Create a new error
+    pub fn new(kind: ErrorKind) -> Self {
+        Self {
+            inner: Context::new(kind),
+            description: None,
         }
     }
+
+    /// Create a new error with the given description
+    pub fn with_description(kind: ErrorKind, description: String) -> Self {
+        Self {
+            inner: Context::new(kind),
+            description: Some(description),
+        }
+    }
+
+    /// Obtain the inner `ErrorKind` for this error
+    #[allow(dead_code)]
+    pub fn kind(&self) -> ErrorKind {
+        *self.inner.get_context()
+    }
+}
+
+impl Fail for Error {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self::new(kind)
+    }
+}
+
+impl From<Context<ErrorKind>> for Error {
+    fn from(inner: Context<ErrorKind>) -> Self {
+        Self {
+            inner,
+            description: None,
+        }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.description {
+            Some(ref desc) => write!(f, "{}: {}", &self.inner, desc),
+            None => Display::fmt(&self.inner, f),
+        }
+    }
+}
+
+/// Kinds of errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ErrorKind {
+    /// Error in configuration file
+    #[fail(display = "config error")]
+    ConfigError,
+
+    /// Malformatted or otherwise invalid cryptographic key
+    #[fail(display = "invalid key")]
+    InvalidKey,
+
+    /// Input/output error
+    #[fail(display = "I/O error")]
+    IoError,
+
+    /// Signing operation failed
+    #[fail(display = "signing operation failed")]
+    SigningError,
 }
 
 /// Create a new error (of a given enum variant) with a formatted message
 macro_rules! err {
     ($variant:ident, $msg:expr) => {
-        ::error::Error::$variant { description: $msg.to_owned() }
+        ::error::Error::with_description(
+            ::error::ErrorKind::$variant,
+            $msg.to_string()
+        )
     };
     ($variant:ident, $fmt:expr, $($arg:tt)+) => {
-        ::error::Error::$variant { description: format!($fmt, $($arg)+) }
+        ::error::Error::with_description(
+            ::error::ErrorKind::$variant,
+            format!($fmt, $($arg)+)
+        )
     };
+}
+
+impl From<io::Error> for Error {
+    fn from(other: io::Error) -> Self {
+        err!(IoError, other)
+    }
 }


### PR DESCRIPTION
Split Error into an Error struct and ErrorKind enum, storing the description in the struct since it's common to all variants.