### PR TITLE
Make `ed25519::KeyRing` a global static

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,9 +251,9 @@ dependencies = [
  "serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory-dalek 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory-yubihsm 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)",
+ "signatory-dalek 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)",
+ "signatory-yubihsm 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)",
  "x25519-dalek 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "signatory"
 version = "0.9.0-alpha3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tendermint/signatory.git#a09eaae7bea74ccd935ff2fbf45fc0bd98189502"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -666,21 +666,21 @@ dependencies = [
 [[package]]
 name = "signatory-dalek"
 version = "0.9.0-alpha3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tendermint/signatory.git#a09eaae7bea74ccd935ff2fbf45fc0bd98189502"
 dependencies = [
  "digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)",
 ]
 
 [[package]]
 name = "signatory-yubihsm"
 version = "0.9.0-alpha3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/tendermint/signatory.git#a09eaae7bea74ccd935ff2fbf45fc0bd98189502"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)",
  "yubihsm 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -923,9 +923,9 @@ dependencies = [
 "checksum serde_derive 1.0.79 (registry+https://github.com/rust-lang/crates.io-index)" = "31569d901045afbff7a9479f793177fe9259819aff10ab4f89ef69bbc5f567fe"
 "checksum serde_json 1.0.27 (registry+https://github.com/rust-lang/crates.io-index)" = "59790990c5115d16027f00913e2e66de23a51f70422e549d2ad68c8c5f268f1c"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
-"checksum signatory 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)" = "edfb9222245fe8ff185016fa4e4560fded1143e665e27d8cb7763e840dfb1692"
-"checksum signatory-dalek 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)" = "1437be1a9e57397e6e8c07b0cbc435215320cdc75ce9132b8aee637c9e807e03"
-"checksum signatory-yubihsm 0.9.0-alpha3 (registry+https://github.com/rust-lang/crates.io-index)" = "b54edd56d0e3a6c5491e2be0659968e79cf0c61944c6f362d219f69dc23ed152"
+"checksum signatory 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)" = "<none>"
+"checksum signatory-dalek 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)" = "<none>"
+"checksum signatory-yubihsm 0.9.0-alpha3 (git+https://github.com/tendermint/signatory.git)" = "<none>"
 "checksum simplelog 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9cc12b39fdf4c9a07f88bffac2d628f0118ed5ac077a4b0feece61fadf1429e5"
 "checksum subtle 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5938f1b89f10d6356339f071eca74209deeae0b6891c2678d655feb78637e369"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_derive = "1.0"
 sha2 = "0.7"
 hkdf = "0.5"
 ring = "0.13"
-signatory = "0.9.0-alpha3"
+signatory = { version = "0.9.0-alpha3", features = ["ed25519"] }
 signatory-dalek = "0.9.0-alpha3"
 signatory-yubihsm = { version = "0.9.0-alpha3", optional = true }
 yubihsm = { version = "0.16", optional = true }
@@ -42,3 +42,8 @@ prost-derive = {git = "https://github.com/Liamsi/prost", branch = "prost_amino_d
 [features]
 yubihsm-provider = ["signatory-yubihsm/usb", "yubihsm/usb"]
 yubihsm-mockhsm = ["yubihsm-provider", "signatory-yubihsm/mockhsm", "yubihsm/mockhsm"]
+
+[patch.crates-io]
+signatory = { git = "https://github.com/tendermint/signatory.git" }
+signatory-dalek = { git = "https://github.com/tendermint/signatory.git" }
+signatory-yubihsm = { git = "https://github.com/tendermint/signatory.git" }

--- a/kms.toml.example
+++ b/kms.toml.example
@@ -3,7 +3,7 @@
 # Copy this to 'kms.toml' and edit for your own purposes
 
 [providers.dalek.keys]
-example-key-1 = { path = "path/to/example.key" }
+validator-key-1 = { path = "path/to/validator.key" }
 
 [providers.yubihsm.connector1]
 http = { addr = "127.0.0.1", port = 12345 }
@@ -11,7 +11,7 @@ auth = { key-id = 1, password = "example" } # password-file = "path/to/password.
 keys = { example-key-42 = { key-id = 42 }, example-key-42 = { key-id = 43 } }
 
 [secret-connection]
-secret-key-path = "/tmp/lolkey2"
+secret-key-path = "path/to/kms-node.key"
 
 [validators]
 example1 = { addr = "example1.example.com", port = 26657 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -5,14 +5,15 @@
 //! To dance around the fact the KMS isn't actually a service, we refer to it
 //! as a "Key Management System".
 
-use std::panic;
-use std::sync::Arc;
-use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use signatory::Ed25519Seed;
+use std::{
+    panic,
+    thread::{self, JoinHandle},
+    time::Duration,
+};
 
 use config::ValidatorConfig;
-use ed25519::Keyring;
-use failure::Error;
+use error::Error;
 use session::Session;
 
 /// How long to wait after a crash before respawning (in seconds)
@@ -31,9 +32,13 @@ pub struct Client {
 
 impl Client {
     /// Spawn a new client, returning a handle so it can be joined
-    pub fn spawn(label: String, config: ValidatorConfig, keyring: Arc<Keyring>) -> Self {
+    pub fn spawn(
+        label: String,
+        config: ValidatorConfig,
+        secret_connection_key: Ed25519Seed,
+    ) -> Self {
         Self {
-            handle: thread::spawn(move || client_loop(&label, &config, &keyring)),
+            handle: thread::spawn(move || client_loop(&label, config, &secret_connection_key)),
         }
     }
 
@@ -44,44 +49,38 @@ impl Client {
 }
 
 /// Main loop for all clients. Handles reconnecting in the event of an error
-fn client_loop(label: &str, config: &ValidatorConfig, keyring: &Arc<Keyring>) {
-    let addr = &config.addr;
-    let port = config.port;
-    let info = format!("{} ({}:{})", label, addr, port);
+fn client_loop(label: &str, config: ValidatorConfig, secret_connection_key: &Ed25519Seed) {
+    let ValidatorConfig {
+        addr,
+        port,
+        reconnect,
+    } = config;
+    let peer_info = format!("{} ({}:{})", label, &addr, port);
 
-    loop {
-        match panic::catch_unwind(|| client_session(addr, port, keyring)) {
-            Ok(result) => match result {
-                Ok(_) => {
-                    info!("[{}] session closed gracefully", &info);
-                    return;
-                }
-                Err(e) => error!("[{}] {}", &info, e),
-            },
-            Err(val) => {
-                if let Some(e) = val.downcast_ref::<String>() {
-                    error!("[{}] client panic! {}", &info, e);
-                } else if let Some(e) = val.downcast_ref::<&str>() {
-                    error!("[{}] client panic! {}", &info, e);
-                } else {
-                    error!("[{}] client panic! (unknown cause)", &info);
-                }
-            }
-        }
+    while let Err(e) = client_session(addr.clone(), port, secret_connection_key) {
+        error!("[{}] {}", &peer_info, e);
 
         // Break out of the loop if auto-reconnect is explicitly disabled
-        if config.reconnect.is_some() && !config.reconnect.unwrap() {
-            break;
+        if reconnect {
+            // TODO: configurable respawn delay
+            thread::sleep(Duration::from_secs(RESPAWN_DELAY));
+        } else {
+            return;
         }
-
-        // TODO: configurable respawn delay
-        thread::sleep(Duration::from_secs(RESPAWN_DELAY))
     }
+
+    info!("[{}] session closed gracefully", &peer_info);
 }
 
 /// Establish a session with the validator and handle incoming requests
-fn client_session(addr: &str, port: u16, keyring: &Arc<Keyring>) -> Result<(), Error> {
-    let mut session = Session::new(addr, port, Arc::clone(keyring))?;
-    while session.handle_request()? {}
-    Ok(())
+fn client_session(
+    addr: String,
+    port: u16,
+    secret_connection_key: &Ed25519Seed,
+) -> Result<(), Error> {
+    panic::catch_unwind(move || {
+        let mut session = Session::new(&addr, port, &secret_connection_key)?;
+        while session.handle_request()? {}
+        Ok(())
+    }).unwrap_or_else(|e| Err(Error::from_panic(&e)))
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,9 +1,12 @@
 use abscissa::{Callable, GlobalConfig};
-use std::{collections::BTreeMap, process, sync::Arc};
+use signatory::{self, Decode, Ed25519Seed, Encode};
+use signatory_dalek::Ed25519Signer;
+use std::{collections::BTreeMap, process};
 
 use client::Client;
-use config::{KMSConfig, ValidatorConfig};
-use ed25519::Keyring;
+use config::{KMSConfig, SecretConnectionConfig, ValidatorConfig};
+use ed25519::{KeyRing, PublicKey, SECRET_KEY_ENCODING};
+use error::Error;
 
 /// The `run` command
 #[derive(Debug, Options)]
@@ -37,16 +40,21 @@ impl Callable for RunCommand {
 
         let config = KMSConfig::get_global();
 
-        let keyring = Arc::new({
-            Keyring::from_config(&config.secret_connection.secret_key_path, &config.providers)
-                .unwrap_or_else(|e| {
-                    status_err!("couldn't load keyring: {}", e);
-                    process::exit(1);
-                })
+        let secret_connection_key = load_secret_connection_key(&config.secret_connection)
+            .unwrap_or_else(|e| {
+                status_err!("couldn't load secret connection key: {}", e);
+                process::exit(1);
+            });
+
+        log_kms_node_id(&secret_connection_key);
+
+        KeyRing::load_from_config(&config.providers).unwrap_or_else(|e| {
+            status_err!("couldn't load keyring: {}", e);
+            process::exit(1);
         });
 
         // Spawn the validator client threads
-        let validator_clients = spawn_validator_clients(&config.validators, &keyring);
+        let validator_clients = spawn_validator_clients(&config.validators, &secret_connection_key);
 
         // Wait for the validator client threads to exit
         // TODO: Find something more useful for this thread to do
@@ -56,15 +64,39 @@ impl Callable for RunCommand {
     }
 }
 
+/// Initialize KMS secret connection private key
+fn load_secret_connection_key(config: &SecretConnectionConfig) -> Result<Ed25519Seed, Error> {
+    let key_path = &config.secret_key_path;
+
+    if key_path.exists() {
+        Ok(Ed25519Seed::decode_from_file(key_path, SECRET_KEY_ENCODING)
+            .map_err(|e| err!(ConfigError, "error loading {}: {}", key_path.display(), e))?)
+    } else {
+        let seed = Ed25519Seed::generate();
+        seed.encode_to_file(key_path, SECRET_KEY_ENCODING)?;
+        Ok(seed)
+    }
+}
+
+/// Log the KMS node ID
+fn log_kms_node_id(seed: &Ed25519Seed) {
+    let public_key = PublicKey::from(signatory::public_key(&Ed25519Signer::from(seed)).unwrap());
+    info!("KMS node ID: {}", &public_key);
+}
+
 /// Spawn validator client threads (which provide KMS service to the
 /// validators they connect to)
 fn spawn_validator_clients(
     config: &BTreeMap<String, ValidatorConfig>,
-    keyring: &Arc<Keyring>,
+    secret_connection_key: &Ed25519Seed,
 ) -> Vec<Client> {
     config
         .iter()
         .map(|(label, validator_config)| {
-            Client::spawn(label.clone(), validator_config.clone(), Arc::clone(keyring))
+            Client::spawn(
+                label.clone(),
+                validator_config.clone(),
+                secret_connection_key.clone(),
+            )
         }).collect()
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -41,7 +41,8 @@ pub struct ValidatorConfig {
     pub port: u16,
 
     /// Automatically reconnect on error? (default: true)
-    pub reconnect: Option<bool>,
+    #[serde(default = "reconnect_default")]
+    pub reconnect: bool,
 }
 
 #[derive(Clone, Deserialize, Debug)]
@@ -59,4 +60,9 @@ pub struct SecretConnectionConfig {
     /// Path to our identity key
     #[serde(rename = "secret-key-path")]
     pub secret_key_path: PathBuf,
+}
+
+/// Default value for the `ValidatorConfig` reconnect field
+fn reconnect_default() -> bool {
+    true
 }

--- a/src/ed25519/keyring.rs
+++ b/src/ed25519/keyring.rs
@@ -1,10 +1,5 @@
-use signatory::{
-    self,
-    encoding::{Decode, Encode, Encoding},
-    Ed25519Seed, Ed25519Signature,
-};
-use signatory_dalek::Ed25519Signer as DalekSigner;
-use std::{collections::HashMap, panic::RefUnwindSafe, path::Path};
+use signatory::Ed25519Signature;
+use std::{collections::BTreeMap, sync::RwLock};
 
 use super::{PublicKey, Signer};
 use config::ProviderConfig;
@@ -14,81 +9,62 @@ use super::signer::dalek;
 #[cfg(feature = "yubihsm-provider")]
 use super::signer::yubihsm;
 
-pub struct Keyring {
-    secret_connection_signer: DalekSigner,
-    signing_keys: HashMap<PublicKey, Signer>,
+lazy_static! {
+    static ref GLOBAL_KEYRING: RwLock<KeyRing> = RwLock::new(KeyRing(BTreeMap::default()));
 }
 
-impl Keyring {
+pub struct KeyRing(BTreeMap<PublicKey, Signer>);
+
+impl KeyRing {
     /// Create a keyring from the given provider configuration
-    pub fn from_config(seccon_key_path: &Path, config: &ProviderConfig) -> Result<Self, Error> {
-        let secret_connection_signer = create_seccon_signer(seccon_key_path)?;
+    pub fn load_from_config(config: &ProviderConfig) -> Result<(), Error> {
+        let mut keyring = GLOBAL_KEYRING.write().unwrap();
 
-        let mut signers = Vec::<Signer>::new();
-        dalek::create_signers(&mut signers, config.dalek.as_ref())?;
-
-        #[cfg(feature = "yubihsm-provider")]
-        yubihsm::create_signers(&mut signers, &config.yubihsm)?;
-
-        let mut signing_keys = HashMap::new();
-
-        for mut signer in signers {
-            let public_key = signer.public_key;
-            info!(
-                "Added {}:{} {}",
-                signer.provider_name, signer.key_id, signer.public_key
-            );
-            signing_keys.insert(signer.public_key, signer);
+        // Clear the current global keyring
+        if !keyring.0.is_empty() {
+            info!("Clearing keyring");
+            keyring.0.clear();
         }
 
-        Ok(Self {
-            secret_connection_signer,
-            signing_keys,
-        })
-    }
+        dalek::init(&mut keyring, config.dalek.as_ref())?;
 
-    /// Get the signer which authenticates new `SecretConnection` sessions
-    pub fn secret_connection_signer(&self) -> &DalekSigner {
-        &self.secret_connection_signer
+        #[cfg(feature = "yubihsm-provider")]
+        yubihsm::init(&mut keyring, &config.yubihsm)?;
+
+        Ok(())
     }
 
     /// Sign a message using the secret key associated with the given public key
     /// (if it is in our keyring)
-    pub fn sign(&self, public_key: &PublicKey, msg: &[u8]) -> Result<Ed25519Signature, Error> {
-        let signer = self
-            .signing_keys
+    pub fn sign(public_key: &PublicKey, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+        let keyring = GLOBAL_KEYRING.read().unwrap();
+
+        let signer = keyring
+            .0
             .get(public_key)
             .ok_or_else(|| err!(InvalidKey, "not in keyring: {}", public_key))?;
 
         signer.sign(msg)
     }
-}
 
-// TODO: ensure keyring is actually unwind safe
-// The `yubihsm-rs` crate uses interior mutability, for example, and
-// therefore is generally not unwind safe, but should theoretically be
-// panic-free barring any bugs in the implementation
-impl RefUnwindSafe for Keyring {}
+    /// Add a key to the keyring, returning an error if we already have a
+    /// signer registered for the given public key
+    pub(super) fn add(&mut self, public_key: PublicKey, signer: Signer) -> Result<(), Error> {
+        info!(
+            "Adding {}:{} {}",
+            signer.provider_name, signer.key_id, public_key
+        );
 
-/// Signatory encoding for the secret key
-const SECCON_KEY_ENCODING: Encoding = Encoding::Raw;
-
-/// Load the key for the `SecretConnection`
-fn create_seccon_signer(key_path: &Path) -> Result<DalekSigner, Error> {
-    let seed = if key_path.exists() {
-        Ed25519Seed::decode_from_file(key_path, SECCON_KEY_ENCODING)?
-    } else {
-        let s = Ed25519Seed::generate();
-        s.encode_to_file(key_path, SECCON_KEY_ENCODING)?;
-        s
-    };
-
-    let signer = DalekSigner::from(&seed);
-
-    info!(
-        "KMS node ID: {}",
-        PublicKey::from(signatory::public_key(&signer)?)
-    );
-
-    Ok(signer)
+        if let Some(other) = self.0.insert(public_key, signer) {
+            Err(err!(
+                InvalidKey,
+                "duplicate signer for {}: {}:{}",
+                public_key,
+                other.provider_name,
+                other.key_id
+            ))
+        } else {
+            Ok(())
+        }
+    }
 }

--- a/src/ed25519/mod.rs
+++ b/src/ed25519/mod.rs
@@ -1,7 +1,12 @@
+use signatory;
+
 mod keyring;
 mod public_key;
 mod signer;
 
-pub use self::keyring::Keyring;
+pub use self::keyring::KeyRing;
 pub use self::public_key::{PublicKey, PUBLIC_KEY_SIZE};
 pub use self::signer::Signer;
+
+/// Encoding for secret keys
+pub const SECRET_KEY_ENCODING: signatory::Encoding = signatory::Encoding::Raw;

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -5,7 +5,7 @@ use std::fmt::{self, Display};
 use error::Error;
 
 /// Ed25519 public keys
-#[derive(Copy, Clone, Eq, PartialEq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct PublicKey(Ed25519PublicKey);
 
 impl PublicKey {

--- a/src/ed25519/signer/mod.rs
+++ b/src/ed25519/signer/mod.rs
@@ -4,7 +4,6 @@ pub mod dalek;
 #[cfg(feature = "yubihsm-provider")]
 pub mod yubihsm;
 
-use super::PublicKey;
 use error::Error;
 
 /// Wrapper for an Ed25519 signing provider (i.e. trait object)
@@ -15,9 +14,6 @@ pub struct Signer {
     /// ID which identifies this key (should be unique-per-provider)
     pub key_id: String,
 
-    /// Public key for this signer
-    pub public_key: PublicKey,
-
     /// Signer trait object
     provider: Box<SignerTrait<Ed25519Signature>>,
 }
@@ -27,13 +23,11 @@ impl Signer {
     pub fn new(
         provider_name: &'static str,
         key_id: String,
-        public_key: PublicKey,
         provider: Box<SignerTrait<Ed25519Signature>>,
     ) -> Self {
         Self {
             provider_name,
             key_id,
-            public_key,
             provider,
         }
     }

--- a/src/ed25519/signer/yubihsm.rs
+++ b/src/ed25519/signer/yubihsm.rs
@@ -1,16 +1,12 @@
 //! YubiHSM2-based signer
 // TODO: finish implementing this!
 
-use super::Signer;
 use config::YubihsmConfig;
+use ed25519::KeyRing;
 use error::Error;
 
 /// Create hardware-backed YubiHSM signer objects from the given configuration
-// TODO: return an iterator rather than taking an `&mut Vec<Signer>`?
-pub fn create_signers(
-    _signers: &mut Vec<Signer>,
-    config: &Option<YubihsmConfig>,
-) -> Result<(), Error> {
+pub fn init(_keyring: &mut KeyRing, config: &Option<YubihsmConfig>) -> Result<(), Error> {
     if config.is_none() {
         return Ok(());
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,12 +1,12 @@
 //! A session with a validator node
 
+use signatory::{ed25519, Ed25519Seed};
+use signatory_dalek::Ed25519Signer;
 use std::io::Write;
 use std::net::TcpStream;
-use std::sync::Arc;
 use types::{PubKeyMsg, TendermintSign};
 
-use ed25519::Keyring;
-use failure::Error;
+use error::Error;
 use prost::Message;
 use rpc::{Request, Response};
 use secret_connection::SecretConnection;
@@ -15,21 +15,17 @@ use secret_connection::SecretConnection;
 pub struct Session {
     /// TCP connection to a validator node
     connection: SecretConnection<TcpStream>,
-
-    /// Keyring of signature keys
-    keyring: Arc<Keyring>,
 }
 
 impl Session {
     /// Create a new session with the validator at the given address/port
-    pub fn new(addr: &str, port: u16, keyring: Arc<Keyring>) -> Result<Self, Error> {
+    pub fn new(addr: &str, port: u16, secret_connection_key: &Ed25519Seed) -> Result<Self, Error> {
         debug!("Connecting to {}:{}...", addr, port);
         let socket = TcpStream::connect(format!("{}:{}", addr, port))?;
-        let connection = SecretConnection::new(socket, keyring.secret_connection_signer())?;
-        Ok(Self {
-            connection,
-            keyring,
-        })
+        let signer = Ed25519Signer::from(secret_connection_key);
+        let public_key = ed25519::public_key(&signer)?;
+        let connection = SecretConnection::new(socket, &public_key, &signer)?;
+        Ok(Self { connection })
     }
 
     /// Handle an incoming request from the validator

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,8 @@
 //! KMS integration test
 
-#[allow(unused_imports)]
+// TODO: get rid of hacks for using RPC types in tests
+#![allow(unused_imports, unused_variables, dead_code)]
+
 #[macro_use]
 extern crate abscissa_derive;
 #[macro_use]
@@ -32,7 +34,6 @@ use signatory::{
 };
 use signatory_dalek::Ed25519Signer;
 use std::ffi::OsStr;
-#[allow(unused_imports)]
 use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::{Child, Command};
@@ -129,7 +130,8 @@ fn test_handle_poisonpill() {
     let (_, signer) = test_key();
     // Here we reply to the kms with a "remote" ephermal key, auth signature etc:
     let socket_cp = kms.socket.try_clone().unwrap();
-    let mut connection = SecretConnection::new(socket_cp, &signer).unwrap();
+    let public_key = signatory::public_key(&signer).unwrap();
+    let mut connection = SecretConnection::new(socket_cp, &public_key, &signer).unwrap();
 
     // use the secret connection to send a message
     let pill = types::PoisonPillMsg {};


### PR DESCRIPTION
Changes the Ed25519 signer keyring from an `Arc<Mutex<_>>` to a static global `RwLock<KeyRing>`.

This avoids having to move `KeyRing` across the unwind boundary, which means we no longer have to `impl RefUnwindSafe` which is a big plus.

It also means `KeyRing` is accessible from any scope and we don't have to worry about passing it around as an argument.

This additionally puts the `SecretConnection` key management more or less back to where it was in the original PR, factored out of `KeyRing` and back into `RunCommand`. There and back again.