### PR TITLE
Add 'yubihsm test' command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,11 +19,16 @@ jobs:
           cargo clippy --version
           cargo clippy --all-features
     - run:
-        name: build (default features)
+        name: build
         command: |
           rustc --version
           cargo --version
           cargo build
+    - run:
+        name: build --release
+        command: |
+          rustc --version
+          cargo --version
           cargo build --release
     - run:
         name: build --all-features (debug)
@@ -31,14 +36,6 @@ jobs:
           rustc --version
           cargo --version
           cargo build --all-features
-    - run:
-        # NOTE: we can't build --all-features --release because one of the
-        # features is `yubihsm-mock` which can't be used in release builds
-        name: build --features=yubihsm --release
-        command: |
-          rustc --version
-          cargo --version
-          cargo build --features=yubihsm --release
     - run:
         name: test --all-features
         command: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ subtle-encoding = "0.2"
 x25519-dalek = { version = "0.3", default-features = false, features = ["std", "u64_backend"] }
 
 [features]
-default = ["softsign"]
+default = ["softsign", "yubihsm"]
 softsign = []
 yubihsm = ["signatory-yubihsm/usb"] # USB only for now
 yubihsm-mock = ["yubihsm", "signatory-yubihsm/mockhsm"]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -47,6 +47,8 @@ impl KmsCommand {
     pub fn verbose(&self) -> bool {
         match self {
             KmsCommand::Run(run) => run.verbose,
+            #[cfg(feature = "yubihsm")]
+            KmsCommand::Yubihsm(yubihsm) => yubihsm.verbose(),
             _ => false,
         }
     }

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -30,7 +30,7 @@ pub struct GenerateCommand {
 
     /// Key IDs to generate
     #[options(free)]
-    key_ids: Vec<String>,
+    key_ids: Vec<u16>,
 }
 
 impl Callable for GenerateCommand {
@@ -54,17 +54,12 @@ impl Callable for GenerateCommand {
 
         let mut hsm = yubihsm::get_hsm_client();
 
-        for key_id_str in &self.key_ids {
-            let key_id = key_id_str.parse::<yubihsm::ObjectId>().unwrap_or_else(|e| {
-                status_err!("bad key id: {} ({})", key_id_str, e);
-                process::exit(1);
-            });
-
+        for key_id in &self.key_ids {
             let label =
                 yubihsm::ObjectLabel::from(self.label.as_ref().map(|l| l.as_ref()).unwrap_or(""));
 
             if let Err(e) = hsm.generate_asymmetric_key(
-                key_id,
+                *key_id,
                 label,
                 DEFAULT_DOMAINS,
                 DEFAULT_CAPABILITIES,
@@ -74,7 +69,7 @@ impl Callable for GenerateCommand {
                 process::exit(1);
             }
 
-            let public_key = PublicKey::from(hsm.get_pubkey(key_id).unwrap_or_else(|e| {
+            let public_key = PublicKey::from(hsm.get_pubkey(*key_id).unwrap_or_else(|e| {
                 status_err!("couldn't get public key for key #{}: {}", key_id, e);
                 process::exit(1);
             }));

--- a/src/commands/yubihsm/mod.rs
+++ b/src/commands/yubihsm/mod.rs
@@ -5,8 +5,9 @@ use abscissa::Callable;
 mod detect;
 mod help;
 mod keys;
+mod test;
 
-pub use self::{detect::DetectCommand, help::HelpCommand, keys::KeysCommand};
+pub use self::{detect::DetectCommand, help::HelpCommand, keys::KeysCommand, test::TestCommand};
 
 /// The `yubihsm` subcommand
 #[derive(Debug, Options)]
@@ -19,6 +20,9 @@ pub enum YubihsmCommand {
 
     #[options(help = "key management subcommands")]
     Keys(KeysCommand),
+
+    #[options(help = "perform a signing test")]
+    Test(TestCommand),
 }
 
 // TODO: custom derive in abscissa
@@ -32,6 +36,7 @@ impl Callable for YubihsmCommand {
             YubihsmCommand::Detect(detect) => detect.call(),
             YubihsmCommand::Help(help) => help.call(),
             YubihsmCommand::Keys(keys) => keys.call(),
+            YubihsmCommand::Test(test) => test.call(),
         }
     }
 }
@@ -42,6 +47,14 @@ impl YubihsmCommand {
             YubihsmCommand::Detect(detect) => detect.config.as_ref().map(|s| s.as_ref()),
             YubihsmCommand::Keys(keys) => keys.config_path(),
             _ => None,
+        }
+    }
+
+    pub(super) fn verbose(&self) -> bool {
+        match self {
+            YubihsmCommand::Detect(detect) => detect.verbose,
+            YubihsmCommand::Test(test) => test.verbose,
+            _ => false,
         }
     }
 }

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,0 +1,49 @@
+use abscissa::Callable;
+use std::{
+    thread,
+    time::{Duration, Instant},
+};
+use yubihsm;
+
+// TODO: figure out rough size of the proposal amino message for testing
+const TEST_MESSAGE: &[u8; 128] = &[0u8; 128];
+
+/// The `yubihsm test` subcommand
+#[derive(Debug, Default, Options)]
+pub struct TestCommand {
+    /// Path to configuration file
+    #[options(short = "c", long = "config")]
+    pub config: Option<String>,
+
+    /// Print debugging information
+    #[options(short = "v", long = "verbose")]
+    pub verbose: bool,
+
+    /// Key ID to use for test
+    #[options(free)]
+    key_id: u16,
+}
+
+impl Callable for TestCommand {
+    /// Perform a signing test using the current HSM configuration
+    fn call(&self) {
+        let mut hsm = yubihsm::get_hsm_client();
+
+        loop {
+            let started_at = Instant::now();
+
+            if let Err(e) = hsm.sign_ed25519(self.key_id, TEST_MESSAGE.as_ref()) {
+                status_err!("signature operation failed: {}", e);
+                thread::sleep(Duration::from_millis(250));
+            } else {
+                let duration = Instant::now().duration_since(started_at);
+                status_ok!(
+                    "Success",
+                    "signed message using key ID #{} in {} ms",
+                    self.key_id,
+                    duration.as_secs() * 1000 + u64::from(duration.subsec_millis())
+                );
+            }
+        }
+    }
+}

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -12,9 +12,9 @@ path = "path/to/validator.key"
 
 [[providers.yubihsm]]
 adapter = { type = "usb" }
-auth = { key = 1, password = "example" }
-serial-number = "0123456789"
+auth = { key = 1, password = "password" } # Default YubiHSM admin password. Change ASAP!
 keys = [{ id = "gaia-9000", key = 42 }, { id = "gaia-9001", key = 43 }]
+#serial-number = "0123456789"
 
 [secret-connection]
 secret-key-path = "path/to/kms-node.key"


### PR DESCRIPTION
This performs an Ed25519 stress test on a YubiHSM, signing messages as quickly as it can.

If an error occurs during signing, it sleeps briefly and then resumes the stress test, ideally picking right back up again once the problem has been resolved.

This code should be panic free (in a perfect world). If it panics, there's a bug. So far in my initial tests with the USB driver, it has survived repeatedly disconnecting and reconnecting the YubiHSM2 as well as moving it to different USB ports.