### PR TITLE
Re-enable deny(warnings); make a lib crate

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,12 +1,21 @@
 //! Abscissa `Application` for the KMS
 
-use abscissa::{Application, LoggingConfig};
+use abscissa::{self, Application, LoggingConfig};
 
 use commands::KmsCommand;
 use config::KmsConfig;
 
+/// The `tmkms` application
 #[derive(Debug)]
 pub struct KmsApplication;
+
+impl KmsApplication {
+    /// Boot the application
+    // TODO: use the upstream implementation of this method
+    pub fn boot() {
+        abscissa::boot(KmsApplication)
+    }
+}
 
 impl Application for KmsApplication {
     type Cmd = KmsCommand;

--- a/src/bin/tmkms/main.rs
+++ b/src/bin/tmkms/main.rs
@@ -1,0 +1,9 @@
+//! Main entry point for the `tmkms` executable
+
+extern crate tmkms;
+use tmkms::KmsApplication;
+
+/// Boot the `tmkms` application
+fn main() {
+    KmsApplication::boot();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,15 @@
 //! Tendermint Key Management System
 
+#![crate_name = "tmkms"]
+#![crate_type = "rlib"]
+#![deny(
+    warnings,
+    missing_docs,
+    unsafe_code,
+    unused_import_braces,
+    unused_qualifications
+)]
+
 extern crate prost_amino as prost;
 #[macro_use]
 extern crate abscissa;
@@ -41,9 +51,4 @@ mod types;
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
 
-use application::KmsApplication;
-
-/// Main entry point
-fn main() {
-    abscissa::boot(KmsApplication);
-}
+pub use application::KmsApplication;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -91,17 +91,21 @@ pub trait TendermintSignable {
 // https://github.com/tendermint/tendermint/blob/455d34134cc53c334ebd3195ac22ea444c4b59bb/types/signed_msg_type.go#L3-L16
 #[derive(Debug, Copy)]
 enum SignedMsgType {
-    // Votes
+    // TODO: Votes
+    #[allow(dead_code)]
     PreVote,
+    #[allow(dead_code)]
     PreCommit,
 
     // Proposals
     Proposal,
 
-    // Heartbeat
+    // TODO: Heartbeat
+    #[allow(dead_code)]
     Heartbeat,
 }
 
+#[allow(dead_code)]
 pub fn extract_actual_len(buf: &[u8]) -> Result<u64, DecodeError> {
     let mut buff = Cursor::new(buf);
     let actual_len = decode_varint(&mut buff)?;
@@ -124,6 +128,7 @@ impl SignedMsgType {
         }
     }
 
+    #[allow(dead_code)]
     fn from(data: u32) -> Result<SignedMsgType, DecodeError> {
         match data {
             0x01 => Ok(SignedMsgType::PreVote),
@@ -134,6 +139,7 @@ impl SignedMsgType {
         }
     }
 
+    #[allow(dead_code)]
     fn is_valid_vote_type(msg_type: SignedMsgType) -> bool {
         match msg_type {
             SignedMsgType::PreVote => true,


### PR DESCRIPTION
Now that #55 is landed, we can re-enable `#![deny(warnings)]` which is a best practice.

This commit does that, and peppers remaining unused code with `#![allow(dead_code)]`.

Additionally, to ensure `#![deny(missing_docs)]` is enforced and to follow (evolving) Abscissa conventions, this refactors the app as a library with a small `main.rs` stub.