### PR TITLE
error.rs: Refactor error handling to use Abscissa newtypes

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use config::ValidatorConfig;
-use error::Error;
+use error::KmsError;
 use session::Session;
 
 /// How long to wait after a crash before respawning (in seconds)
@@ -62,7 +62,11 @@ fn client_loop(config: &ValidatorConfig, secret_connection_key: &Ed25519Seed) {
 }
 
 /// Establish a session with the validator and handle incoming requests
-fn client_session(addr: &str, port: u16, secret_connection_key: &Ed25519Seed) -> Result<(), Error> {
+fn client_session(
+    addr: &str,
+    port: u16,
+    secret_connection_key: &Ed25519Seed,
+) -> Result<(), KmsError> {
     panic::catch_unwind(move || {
         let mut session = Session::new(addr, port, &secret_connection_key)?;
         info!(
@@ -71,5 +75,5 @@ fn client_session(addr: &str, port: u16, secret_connection_key: &Ed25519Seed) ->
         );
         while session.handle_request()? {}
         Ok(())
-    }).unwrap_or_else(|e| Err(Error::from_panic(&e)))
+    }).unwrap_or_else(|e| Err(KmsError::from_panic(&e)))
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -6,7 +6,7 @@ use std::process;
 use client::Client;
 use config::{KmsConfig, SecretConnectionConfig, ValidatorConfig};
 use ed25519::{KeyRing, PublicKey, SECRET_KEY_ENCODING};
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 /// The `run` command
 #[derive(Debug, Options)]
@@ -65,7 +65,7 @@ impl Callable for RunCommand {
 }
 
 /// Initialize KMS secret connection private key
-fn load_secret_connection_key(config: &SecretConnectionConfig) -> Result<Ed25519Seed, Error> {
+fn load_secret_connection_key(config: &SecretConnectionConfig) -> Result<Ed25519Seed, KmsError> {
     let key_path = &config.secret_key_path;
 
     if key_path.exists() {

--- a/src/ed25519/keyring.rs
+++ b/src/ed25519/keyring.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, sync::RwLock};
 
 use super::{PublicKey, Signer};
 use config::provider::ProviderConfig;
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 use super::signer::softsign;
 #[cfg(feature = "yubihsm")]
@@ -17,7 +17,7 @@ pub struct KeyRing(BTreeMap<PublicKey, Signer>);
 
 impl KeyRing {
     /// Create a keyring from the given provider configuration
-    pub fn load_from_config(config: &ProviderConfig) -> Result<(), Error> {
+    pub fn load_from_config(config: &ProviderConfig) -> Result<(), KmsError> {
         let mut keyring = GLOBAL_KEYRING.write().unwrap();
 
         // Clear the current global keyring
@@ -33,7 +33,7 @@ impl KeyRing {
         yubihsm::init(&mut keyring, &config.yubihsm)?;
 
         if keyring.0.is_empty() {
-            Err(err!(ConfigError, "no signing keys configured!"))
+            fail!(ConfigError, "no signing keys configured!")
         } else {
             Ok(())
         }
@@ -41,38 +41,38 @@ impl KeyRing {
 
     /// Add a key to the keyring, returning an error if we already have a
     /// signer registered for the given public key
-    pub(super) fn add(&mut self, public_key: PublicKey, signer: Signer) -> Result<(), Error> {
+    pub(super) fn add(&mut self, public_key: PublicKey, signer: Signer) -> Result<(), KmsError> {
         info!(
             "[keyring:{}:{}] added validator key {}",
             signer.provider_name, signer.key_id, public_key
         );
 
         if let Some(other) = self.0.insert(public_key, signer) {
-            Err(err!(
+            fail!(
                 InvalidKey,
                 "duplicate signer for {}: {}:{}",
                 public_key,
                 other.provider_name,
                 other.key_id
-            ))
+            )
         } else {
             Ok(())
         }
     }
 
-    pub fn get_only_signing_pubkey() -> Result<PublicKey, Error> {
+    pub fn get_only_signing_pubkey() -> Result<PublicKey, KmsError> {
         let keyring = GLOBAL_KEYRING.read().unwrap();
 
         let mut keys = keyring.0.keys();
         if keys.len() > 1 {
-            return Err(err!(InvalidKey, "expected only one key in keyring"));
+            fail!(InvalidKey, "expected only one key in keyring");
         }
         Ok(*keys.next().unwrap())
     }
 
     /// Sign a message using the secret key associated with the given public key
     /// (if it is in our keyring)
-    pub fn sign(public_key: Option<&PublicKey>, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+    pub fn sign(public_key: Option<&PublicKey>, msg: &[u8]) -> Result<Ed25519Signature, KmsError> {
         let keyring = GLOBAL_KEYRING.read().unwrap();
         let signer: &Signer = match public_key {
             Some(public_key) => keyring
@@ -81,11 +81,13 @@ impl KeyRing {
                 .ok_or_else(|| err!(InvalidKey, "not in keyring: {}", public_key))?,
             None => {
                 let mut vals = keyring.0.values();
+
                 if vals.len() > 1 {
-                    return Err(err!(SigningError, "expected only one key in keyring"));
+                    fail!(SigningError, "expected only one key in keyring");
+                } else {
+                    vals.next()
+                        .ok_or_else(|| err!(InvalidKey, "could not get only signer"))?
                 }
-                vals.next()
-                    .ok_or_else(|| err!(InvalidKey, "could not get only signer"))?
             }
         };
 

--- a/src/ed25519/public_key.rs
+++ b/src/ed25519/public_key.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Display};
 #[cfg(feature = "yubihsm")]
 use yubihsm;
 
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 /// Ed25519 public keys
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord)]
@@ -12,7 +12,7 @@ pub struct PublicKey(ed25519::PublicKey);
 
 impl PublicKey {
     /// Convert a bytestring to a public key
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, KmsError> {
         Ok(PublicKey(
             ed25519::PublicKey::from_bytes(bytes).map_err(|e| err!(InvalidKey, "{}", e))?,
         ))

--- a/src/ed25519/signer/mod.rs
+++ b/src/ed25519/signer/mod.rs
@@ -5,7 +5,7 @@ pub mod softsign;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 /// Wrapper for an Ed25519 signing provider (i.e. trait object)
 pub struct Signer {
@@ -35,7 +35,7 @@ impl Signer {
 
     /// Sign the given message using this signer
     #[inline]
-    pub fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, Error> {
+    pub fn sign(&self, msg: &[u8]) -> Result<Ed25519Signature, KmsError> {
         Ok(
             signatory::sign(self.provider.as_ref(), msg)
                 .map_err(|e| err!(SigningError, "{}", e))?,

--- a/src/ed25519/signer/softsign.rs
+++ b/src/ed25519/signer/softsign.rs
@@ -8,14 +8,14 @@ use subtle_encoding::IDENTITY;
 
 use config::provider::softsign::SoftSignConfig;
 use ed25519::{KeyRing, PublicKey, Signer};
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum
 pub const DALEK_PROVIDER_LABEL: &str = "dalek";
 
 /// Create software-backed Ed25519 signer objects from the given configuration
-pub fn init(keyring: &mut KeyRing, configs: &[SoftSignConfig]) -> Result<(), Error> {
+pub fn init(keyring: &mut KeyRing, configs: &[SoftSignConfig]) -> Result<(), KmsError> {
     for config in configs {
         let seed = Ed25519Seed::decode_from_file(config.path.as_path(), IDENTITY).map_err(|e| {
             err!(

--- a/src/ed25519/signer/yubihsm.rs
+++ b/src/ed25519/signer/yubihsm.rs
@@ -5,24 +5,24 @@ use signatory_yubihsm::{self, KeyId};
 
 use config::provider::yubihsm::YubihsmConfig;
 use ed25519::{KeyRing, PublicKey, Signer};
-use error::Error;
+use error::{KmsError, KmsErrorKind::*};
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum
 pub const YUBIHSM_PROVIDER_LABEL: &str = "yubihsm";
 
 /// Create hardware-backed YubiHSM signer objects from the given configuration
-pub fn init(keyring: &mut KeyRing, yubihsm_configs: &[YubihsmConfig]) -> Result<(), Error> {
+pub fn init(keyring: &mut KeyRing, yubihsm_configs: &[YubihsmConfig]) -> Result<(), KmsError> {
     if yubihsm_configs.is_empty() {
         return Ok(());
     }
 
     if yubihsm_configs.len() != 1 {
-        return Err(err!(
+        fail!(
             ConfigError,
             "expected one [yubihsm.provider] in config, found: {}",
             yubihsm_configs.len()
-        ));
+        );
     }
 
     let yubihsm_config = &yubihsm_configs[0];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,8 @@
 #![allow(unused_imports, unused_variables, dead_code)]
 
 #[macro_use]
+extern crate abscissa;
+#[macro_use]
 extern crate abscissa_derive;
 #[macro_use]
 extern crate failure_derive;


### PR DESCRIPTION
The error types were never converted to `abscissa::Error`. This does the conversion, and adds a `KmsError` newtype which replaces the previous `Error` type.