### PR TITLE
Fix some encoding/decoding incompatibilities with tendermint:

### DIFF
--- a/tendermint-rs/src/amino_types/secret_connection.rs
+++ b/tendermint-rs/src/amino_types/secret_connection.rs
@@ -2,7 +2,7 @@
 
 #[derive(Clone, PartialEq, Message)]
 pub struct AuthSigMessage {
-    #[prost(bytes, tag = "1")]
+    #[prost(bytes, tag = "1", amino_name = "tendermint/PubKeyEd25519")]
     pub key: Vec<u8>,
     #[prost(bytes, tag = "2")]
     pub sig: Vec<u8>,


### PR DESCRIPTION
 - use length delimited version of encode / decode (i.e. `encode_length_delimited`, `decode_length_delimited`
 - AuthSigMessage contains prefixed / registered `crypto.PubKey` type
 which, in the KMS, is assumed to be the concrete type`ed25519.PubKeyEd2551` (corresponds to the "amino route": tendermint/PubKeyEd25519)

fix #90 