### PR TITLE
Fix more tendermint compatibility issues

### DIFF
--- a/tendermint-rs/src/amino_types/heartbeat.rs
+++ b/tendermint-rs/src/amino_types/heartbeat.rs
@@ -104,7 +104,7 @@ impl SignableMsg for SignHeartbeatRequest {
             validator_index: hb.validator_index,
             chain_id: chain_id.to_string(),
         };
-        chb.encode(sign_bytes)?;
+        chb.encode_length_delimited(sign_bytes)?;
         Ok(true)
     }
     fn set_signature(&mut self, sig: &ed25519::Signature) {

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -50,16 +50,16 @@ pub struct SignProposalRequest {
 struct CanonicalProposal {
     #[prost(uint32, tag = "1")]
     msg_type: u32, // this is a byte in golang, which is a varint encoded UInt8 (using amino's EncodeUvarint)
-    #[prost(sint64)]
+    #[prost(sfixed64)]
     height: i64,
-    #[prost(sint64)]
+    #[prost(sfixed64)]
     round: i64,
-    #[prost(sint64)]
+    #[prost(sfixed64)]
     pol_round: i64,
     #[prost(message)]
-    timestamp: Option<TimeMsg>,
-    #[prost(message)]
     block_id: Option<CanonicalBlockId>,
+    #[prost(message)]
+    timestamp: Option<TimeMsg>,
     #[prost(string)]
     pub chain_id: String,
 }
@@ -117,7 +117,7 @@ impl SignableMsg for SignProposalRequest {
             timestamp: proposal.timestamp,
         };
 
-        cp.encode(sign_bytes)?;
+        cp.encode_length_delimited(sign_bytes)?;
         Ok(true)
     }
     fn set_signature(&mut self, sig: &ed25519::Signature) {

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -127,7 +127,8 @@ impl SignableMsg for SignVoteRequest {
         let vote = svr.vote.unwrap();
         let cv = CanonicalVote::new(vote, chain_id.as_str());
 
-        cv.encode(sign_bytes)?;
+        cv.encode_length_delimited(sign_bytes)?;
+
         Ok(true)
     }
     fn set_signature(&mut self, sig: &ed25519::Signature) {

--- a/tendermint-rs/src/chain/id.rs
+++ b/tendermint-rs/src/chain/id.rs
@@ -29,7 +29,7 @@ impl Id {
 
         for byte in name.as_bytes() {
             match byte {
-                b'a'...b'z' | b'0'...b'9' | b'-' | b'_' => (),
+                b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'-' | b'_' => (),
                 _ => return Err(Error::Parse),
             }
         }


### PR DESCRIPTION
 - length delimited encoding everywhere 
 - CanonicalProposal matches tendermint's encoding too
 - be less restrictive about the chain-id

after these changes the KMS and tendermint properly understand each other 🎉 (tested locally using secret connection / tcp) 

resolve #94 
resolve #93 