### PR TITLE
Rename 'run' command to 'start' (closes #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,11 @@ the following:
 
 ## Status
 
-Early adopters interested in using YubiHSM2 devices for Cosmos Validator key
-storage can install the (forthcoming) `tmkms` v0.0.1 "Preview Release" using
-the instructions below.
+Tendermint KMS is currently **alpha quality**. It supports YubiHSM2-backed
+signing when used in conjunction with `cosmos-sdk` 0.26.
 
-NOTE: This release does not yet support validator signing. See the following
-issues for the remaining blockers:
-
-- [ ] [Cosmos address (Bech32) support](https://github.com/tendermint/kms/issues/65)
-- [ ] [Update to new signing message format & integration test](https://github.com/tendermint/kms/pull/55)
-- [ ] [Full integration tests: Tendermint <-> KMS](https://github.com/tendermint/kms/issues/44)
+It does NOT yet implement double signing prevention or high availability
+features. These are planned features which will be implemented soon.
 
 ## Supported Platforms
 
@@ -47,30 +42,15 @@ prerequisites for support.
 
 ### Operating Systems
 
-- Linux
-- Windows
-- macOS
+- Linux (recommended)
 - FreeBSD
 - NetBSD
 - OpenBSD
+- macOS
 
 ### CPU Architectures
 
-Rust supports the following CPU architectures:
-
-**Tier 1:**
-
-a.k.a. "guaranteed to work"
-
-- `i686` (32-bit Intel)
-- `x86_64` ("AMD64", "x64") - recommended
-
-**Tier 2:**
-
-a.k.a. "may work". Note that hardware accelerated AES (used for communication
-with YubiHSM2) is not supported on these platforms and they have not been
-rigorously tested for side-channel attack resistance.
-
+- `x86_64` (recommended)
 - `arm` (32-bit ARM)
 - `aarch64` (64-bit ARM)
 - `mips` (32-bit MIPS)
@@ -105,6 +85,24 @@ $ cargo install tmkms
 https://github.com/tendermint/kms/blob/master/tmkms.toml.example
 
 Edit it to match your desired configuration.
+
+## Usage
+
+Start `tmkms` with the following:
+
+
+```
+$ tmkms start
+```
+
+This will read the configuration from the `tmkms.toml` file in the current
+working directory.
+
+To explicitly specify the path to the configuration, use the `-c` flag:
+
+```
+$ tmkms start -c /path/to/tmkms.toml
+```
 
 ## YubiHSM2 Setup
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 mod help;
 mod keygen;
-mod run;
+mod start;
 mod version;
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
@@ -15,7 +15,7 @@ mod yubihsm;
 #[cfg(feature = "yubihsm")]
 pub use self::yubihsm::YubihsmCommand;
 pub use self::{
-    help::HelpCommand, keygen::KeygenCommand, run::RunCommand, version::VersionCommand,
+    help::HelpCommand, keygen::KeygenCommand, start::StartCommand, version::VersionCommand,
 };
 use config::{KmsConfig, CONFIG_FILE_NAME};
 
@@ -28,8 +28,8 @@ pub enum KmsCommand {
     #[options(help = "generate a new software signing key")]
     Keygen(KeygenCommand),
 
-    #[options(help = "run the KMS application")]
-    Run(RunCommand),
+    #[options(help = "start the KMS application")]
+    Start(StartCommand),
 
     #[options(help = "display version information")]
     Version(VersionCommand),
@@ -46,7 +46,7 @@ impl KmsCommand {
     /// Are we configured for verbose logging?
     pub fn verbose(&self) -> bool {
         match self {
-            KmsCommand::Run(run) => run.verbose,
+            KmsCommand::Start(run) => run.verbose,
             #[cfg(feature = "yubihsm")]
             KmsCommand::Yubihsm(yubihsm) => yubihsm.verbose(),
             _ => false,
@@ -59,7 +59,7 @@ impl LoadConfig<KmsConfig> for KmsCommand {
     /// or the default
     fn config_path(&self) -> Option<PathBuf> {
         let config = match self {
-            KmsCommand::Run(run) => run.config.as_ref().map(|s| s.as_ref()),
+            KmsCommand::Start(run) => run.config.as_ref().map(|s| s.as_ref()),
             #[cfg(feature = "yubihsm")]
             KmsCommand::Yubihsm(yubihsm) => yubihsm.config_path(),
             _ => return None,
@@ -76,7 +76,7 @@ impl Callable for KmsCommand {
         match self {
             KmsCommand::Help(help) => help.call(),
             KmsCommand::Keygen(keygen) => keygen.call(),
-            KmsCommand::Run(run) => run.call(),
+            KmsCommand::Start(run) => run.call(),
             KmsCommand::Version(version) => version.call(),
             #[cfg(feature = "yubihsm")]
             KmsCommand::Yubihsm(yubihsm) => yubihsm.call(),

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -5,9 +5,9 @@ use client::Client;
 use config::{KmsConfig, ValidatorConfig};
 use keyring::KeyRing;
 
-/// The `run` command
+/// The `start` command
 #[derive(Debug, Options)]
-pub struct RunCommand {
+pub struct StartCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config")]
     pub config: Option<String>,
@@ -17,7 +17,7 @@ pub struct RunCommand {
     pub verbose: bool,
 }
 
-impl Default for RunCommand {
+impl Default for StartCommand {
     fn default() -> Self {
         Self {
             config: None,
@@ -26,7 +26,7 @@ impl Default for RunCommand {
     }
 }
 
-impl Callable for RunCommand {
+impl Callable for StartCommand {
     /// Run the KMS
     fn call(&self) {
         info!(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -106,7 +106,7 @@ impl KmsDevice {
         // Listen on a random port
         let listener = TcpListener::bind(format!("{}:{}", "127.0.0.1", port)).unwrap();
 
-        let args = &["run", "-c", config.path().to_str().unwrap()];
+        let args = &["start", "-c", config.path().to_str().unwrap()];
         let process = Command::new(KMS_EXE_PATH).args(args).spawn().unwrap();
 
         let (socket, _) = listener.accept().unwrap();
@@ -126,7 +126,7 @@ impl KmsDevice {
         let config = KmsDevice::create_unix_config(&socket_path);
 
         // Launch KMS process first to avoid a race condition on the socket path
-        let args = &["run", "-c", config.path().to_str().unwrap()];
+        let args = &["start", "-c", config.path().to_str().unwrap()];
         let process = Command::new(KMS_EXE_PATH).args(args).spawn().unwrap();
 
         // TODO(amr): find a better way to wait


### PR DESCRIPTION
Match the command name gaiad uses for consistency.