### PR TITLE
tmkms v0.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## [0.1.0] (2018-11-13)
+
+[0.1.0]: https://github.com/tendermint/kms/pull/100
+
+- Initial validator signing support (#95, #91, #86, #80, #55)
+- Support for Bech32-formatted Cosmos keys/addresses (#71)
+- Extract `tendermint` crate as a reusable Rust library (#82)
+- Validator signing via Unix domain socket IPC (#63)
+
 ## 0.0.1 (2018-10-16)
 
-- Initial release
+- Initial "preview" release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.0.1"
+version     = "0.1.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"
@@ -35,7 +35,7 @@ signatory = { version = "0.10", features = ["ed25519"] }
 signatory-dalek = "0.10"
 signatory-yubihsm = { version = "0.10", optional = true }
 subtle-encoding = "0.2"
-tendermint = { version = "0", path = "tendermint-rs" }
+tendermint = { version = "0.1", path = "tendermint-rs" }
 iq-bech32 = "0.1"
 
 [dev-dependencies]


### PR DESCRIPTION
- Initial validator signing support (#95, #91, #86, #80, #55)
- Support for Bech32-formatted Cosmos keys/addresses (#71)
- Extract `tendermint` crate as a reusable Rust library (#82)
- Validator signing via Unix domain socket IPC (#63)

:shipit: 