### PR TITLE
Some minor clarifications, debug output, and fixing the toml.example:

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -36,7 +36,7 @@ pub enum Response {
     PublicKey(PubKeyMsg),
 }
 
-pub trait TendermintResponse: SignableMsg {
+pub trait TendermintRequest: SignableMsg {
     // TODO(ismail): this should take an error as an argument:
     fn build_response(self) -> Response;
 }
@@ -114,7 +114,7 @@ impl Request {
     }
 }
 
-impl TendermintResponse for SignHeartbeatRequest {
+impl TendermintRequest for SignHeartbeatRequest {
     fn build_response(self) -> Response {
         Response::SignedHeartBeat(SignedHeartbeatResponse {
             heartbeat: self.heartbeat,
@@ -123,7 +123,7 @@ impl TendermintResponse for SignHeartbeatRequest {
     }
 }
 
-impl TendermintResponse for SignVoteRequest {
+impl TendermintRequest for SignVoteRequest {
     fn build_response(self) -> Response {
         Response::SignedVote(SignedVoteResponse {
             vote: self.vote,
@@ -132,7 +132,7 @@ impl TendermintResponse for SignVoteRequest {
     }
 }
 
-impl TendermintResponse for SignProposalRequest {
+impl TendermintRequest for SignProposalRequest {
     fn build_response(self) -> Response {
         Response::SignedProposal(SignedProposalResponse {
             proposal: self.proposal,

--- a/tendermint-rs/src/amino_types/signature.rs
+++ b/tendermint-rs/src/amino_types/signature.rs
@@ -1,11 +1,12 @@
 use bytes::BufMut;
 use prost::{DecodeError, EncodeError};
 use signatory::ed25519;
+use std::fmt::Debug;
 
 use chain;
 
 /// Amino messages which are signable within a Tendermint network
-pub trait SignableMsg {
+pub trait SignableMsg: Debug {
     /// Sign this message as bytes
     fn sign_bytes<B: BufMut>(
         &self,

--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -16,7 +16,7 @@ reconnect = true # true is the default
     # UNIX domain socket connection to validator
     #[validator.connection]
     #type = "unix"
-    #socket-path = "path/to/tmkms_example.sock"
+    #socket_path = "path/to/tmkms_example.sock"
 
 [[providers.softsign]]
 id = "gaia-8000"


### PR DESCRIPTION
I tested the unix connection type manually, too and did the following changes:

- socket-path must be socket_path in `tmkms.toml.example` to be parseable
- add std::fmt::Debug to signable messages
- rename TendermintResponse -> TendermintRequest (this trait is used for requests not responses)
- add a few debug outputs