### PR TITLE
tmkms v0.2.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
-## [0.1.0] (2018-11-13)
+## [0.2.0] (2018-11-20)
 
-[0.1.0]: https://github.com/tendermint/kms/pull/100
+- Add `tmkms yubihsm keys import` command (#107)
+- Simplify `tmkms.toml` syntax (#106)
+- Minor clarifications/fixes (#103)
+
+## [0.1.0] (2018-11-13)
 
 - Initial validator signing support (#95, #91, #86, #80, #55)
 - Support for Bech32-formatted Cosmos keys/addresses (#71)
@@ -10,3 +14,6 @@
 ## 0.0.1 (2018-10-16)
 
 - Initial "preview" release
+
+[0.2.0]: https://github.com/tendermint/kms/pull/108
+[0.1.0]: https://github.com/tendermint/kms/pull/100

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.1.0"
+version     = "0.2.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"


### PR DESCRIPTION
- Add `tmkms yubihsm keys import` command (#107)
- Simplify `tmkms.toml` syntax (#106)
- Minor clarifications/fixes (#103)