### PR TITLE
Introduce same validation logic as tendermint

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -10,6 +10,7 @@ use std::{
     io,
 };
 use tendermint;
+use tendermint::amino_types::validate::ValidationError as TmValidationError;
 #[cfg(feature = "yubihsm")]
 use yubihsm;
 
@@ -53,6 +54,10 @@ pub enum KmsErrorKind {
     /// Malformatted or otherwise invalid cryptographic key
     #[fail(display = "invalid key")]
     InvalidKey,
+
+    /// Validation of consensus message failed
+    #[fail(display = "invalid consensus message")]
+    InvalidMessageError,
 
     /// Input/output error
     #[fail(display = "I/O error")]
@@ -133,6 +138,12 @@ impl From<tendermint::Error> for KmsError {
         };
 
         Error::new(kind, None).into()
+    }
+}
+
+impl From<TmValidationError> for KmsError {
+    fn from(other: TmValidationError) -> Self {
+        err!(KmsErrorKind::InvalidMessageError, other).into()
     }
 }
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -88,8 +88,7 @@ impl Request {
         buff.read_exact(&mut amino_pre)?;
         buff.set_position(0);
         let total_len = encoded_len_varint(len).checked_add(len as usize).unwrap();
-        // TODO: find a way to get back the buffer without cloning the cursor here:
-        let rem: Vec<u8> = buff.clone().into_inner()[..total_len].to_vec();
+        let rem = buff.get_ref()[..total_len].to_vec();
         match amino_pre {
             ref pp if *pp == *PP_PREFIX => Ok(Request::PoisonPill(PoisonPillMsg {})),
             ref vt if *vt == *VOTE_PREFIX => Ok(Request::SignVote(SignVoteRequest::decode(&rem)?)),

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,7 @@
 //! Remote Procedure Calls
 
 use bytes::IntoBuf;
-use prost::encoding::decode_varint;
+use prost::encoding::{decode_varint, encoded_len_varint};
 use prost::Message;
 use sha2::{Digest, Sha256};
 use std::io::Cursor;
@@ -87,9 +87,9 @@ impl Request {
         let mut amino_pre = vec![0; 4];
         buff.read_exact(&mut amino_pre)?;
         buff.set_position(0);
+        let total_len = encoded_len_varint(len).checked_add(len as usize).unwrap();
         // TODO: find a way to get back the buffer without cloning the cursor here:
-        let rem: Vec<u8> =
-            buff.clone().into_inner()[..(len.checked_add(1).unwrap() as usize)].to_vec();
+        let rem: Vec<u8> = buff.clone().into_inner()[..total_len].to_vec();
         match amino_pre {
             ref pp if *pp == *PP_PREFIX => Ok(Request::PoisonPill(PoisonPillMsg {})),
             ref vt if *vt == *VOTE_PREFIX => Ok(Request::SignVote(SignVoteRequest::decode(&rem)?)),

--- a/src/session.rs
+++ b/src/session.rs
@@ -3,6 +3,7 @@
 use signatory::ed25519;
 use signatory_dalek::Ed25519Signer;
 use std::{
+    fmt::Debug,
     fs,
     io::{self, Read, Write},
     marker::{Send, Sync},
@@ -126,7 +127,9 @@ where
     }
 
     /// Perform a digital signature operation
-    fn sign(&mut self, mut request: impl TendermintRequest) -> Result<Response, KmsError> {
+    fn sign<T: TendermintRequest + Debug>(&mut self, mut request: T) -> Result<Response, KmsError> {
+        request.validate()?;
+
         let mut to_sign = vec![];
         request.sign_bytes(self.chain_id, &mut to_sign)?;
 

--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -26,7 +26,7 @@ impl ConsensusMessage for BlockId {
         }
         match self.parts_header {
             Some(ref psh) => psh.validate_basic(),
-            None => Ok(()), // TODO: is an empty PartsSetHeader eally OK here?
+            None => Ok(()), // TODO: is an empty PartsSetHeader really OK here?
         }
     }
 }

--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -21,7 +21,8 @@ impl block::ParseId for BlockId {
 
 impl ConsensusMessage for BlockId {
     fn validate_basic(&self) -> Result<(), ValidationError> {
-        if self.hash.len() != SHA256_HASH_SIZE {
+        // Hash can be empty in case of POLBlockID in Proposal.
+        if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
             return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
         }
         match self.parts_header {
@@ -59,7 +60,8 @@ impl ConsensusMessage for PartsSetHeader {
         if self.total < 0 {
             return Err(ValidationError::new(ValidationErrorKind::NegativeTotal));
         }
-        if self.hash.len() != SHA256_HASH_SIZE {
+        // Hash can be empty in case of POLBlockID.PartsHeader in Proposal.
+        if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
             return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
         }
         Ok(())

--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -23,12 +23,12 @@ impl ConsensusMessage for BlockId {
     fn validate_basic(&self) -> Result<(), ValidationError> {
         // Hash can be empty in case of POLBlockID in Proposal.
         if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
-            return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
+            return Err(ValidationErrorKind::InvalidHashSize.into());
         }
-        match self.parts_header {
-            Some(ref psh) => psh.validate_basic(),
-            None => Ok(()), // TODO: is an empty PartsSetHeader really OK here?
-        }
+        // TODO: is an empty PartsSetHeader really OK here?
+        self.parts_header
+            .as_ref()
+            .map_or(Ok(()), |psh| psh.validate_basic())
     }
 }
 
@@ -58,11 +58,11 @@ pub struct PartsSetHeader {
 impl ConsensusMessage for PartsSetHeader {
     fn validate_basic(&self) -> Result<(), ValidationError> {
         if self.total < 0 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativeTotal));
+            return Err(ValidationErrorKind::NegativeTotal.into());
         }
         // Hash can be empty in case of POLBlockID.PartsHeader in Proposal.
         if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
-            return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
+            return Err(ValidationErrorKind::InvalidHashSize.into());
         }
         Ok(())
     }

--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -1,7 +1,8 @@
+use super::validate::{ConsensusMessage, ValidationError, ValidationErrorKind};
 use algorithm::HashAlgorithm;
 use block;
 use error::Error;
-use hash::Hash;
+use hash::{Hash, SHA256_HASH_SIZE};
 
 #[derive(Clone, PartialEq, Message)]
 pub struct BlockId {
@@ -15,6 +16,18 @@ impl block::ParseId for BlockId {
     fn parse_block_id(&self) -> Result<block::Id, Error> {
         let hash = Hash::new(HashAlgorithm::Sha256, &self.hash)?;
         Ok(block::Id::new(hash))
+    }
+}
+
+impl ConsensusMessage for BlockId {
+    fn validate_basic(&self) -> Result<(), ValidationError> {
+        if self.hash.len() != SHA256_HASH_SIZE {
+            return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
+        }
+        match self.parts_header {
+            Some(ref psh) => psh.validate_basic(),
+            None => Ok(()), // TODO: is an empty PartsSetHeader eally OK here?
+        }
     }
 }
 
@@ -39,6 +52,18 @@ pub struct PartsSetHeader {
     pub total: i64,
     #[prost(bytes, tag = "2")]
     pub hash: Vec<u8>,
+}
+
+impl ConsensusMessage for PartsSetHeader {
+    fn validate_basic(&self) -> Result<(), ValidationError> {
+        if self.total < 0 {
+            return Err(ValidationError::new(ValidationErrorKind::NegativeTotal));
+        }
+        if self.hash.len() != SHA256_HASH_SIZE {
+            return Err(ValidationError::new(ValidationErrorKind::InvalidHashSize));
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, PartialEq, Message)]

--- a/tendermint-rs/src/amino_types/mod.rs
+++ b/tendermint-rs/src/amino_types/mod.rs
@@ -12,6 +12,7 @@ pub mod remote_error;
 pub mod secret_connection;
 pub mod signature;
 pub mod time;
+pub mod validate;
 pub mod vote;
 
 pub use self::{
@@ -24,5 +25,6 @@ pub use self::{
     secret_connection::AuthSigMessage,
     signature::{SignableMsg, SignedMsgType},
     time::TimeMsg,
+    validate::ConsensusMessage,
     vote::{SignVoteRequest, SignedVoteResponse, AMINO_NAME as VOTE_AMINO_NAME},
 };

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -129,9 +129,7 @@ impl SignableMsg for SignProposalRequest {
     fn validate(&self) -> Result<(), ValidationError> {
         match self.proposal {
             Some(ref p) => p.validate_basic(),
-            None => Err(ValidationError::new(
-                ValidationErrorKind::MissingConsensusMessage,
-            )),
+            None => Err(ValidationErrorKind::MissingConsensusMessage.into()),
         }
     }
 }
@@ -139,18 +137,16 @@ impl SignableMsg for SignProposalRequest {
 impl ConsensusMessage for Proposal {
     fn validate_basic(&self) -> Result<(), ValidationError> {
         if self.msg_type != SignedMsgType::Proposal.to_u32() {
-            return Err(ValidationError::new(
-                ValidationErrorKind::InvalidMessageType,
-            ));
+            return Err(ValidationErrorKind::InvalidMessageType.into());
         }
         if self.height < 0 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativeHeight));
+            return Err(ValidationErrorKind::NegativeHeight.into());
         }
         if self.round < 0 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativeRound));
+            return Err(ValidationErrorKind::NegativeRound.into());
         }
         if self.pol_round < -1 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativePOLRound));
+            return Err(ValidationErrorKind::NegativePOLRound.into());
         }
         // TODO validate proposal's block_id
 

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -126,6 +126,14 @@ impl SignableMsg for SignProposalRequest {
             prop.signature = sig.clone().into_vec();
         }
     }
+    fn validate(&self) -> Result<(), ValidationError> {
+        match self.proposal {
+            Some(ref p) => p.validate_basic(),
+            None => Err(ValidationError::new(
+                ValidationErrorKind::MissingConsensusMessage,
+            )),
+        }
+    }
 }
 
 impl ConsensusMessage for Proposal {

--- a/tendermint-rs/src/amino_types/signature.rs
+++ b/tendermint-rs/src/amino_types/signature.rs
@@ -1,12 +1,13 @@
 use bytes::BufMut;
 use prost::{DecodeError, EncodeError};
 use signatory::ed25519;
-use std::fmt::Debug;
+
+use amino_types::validate::ValidationError;
 
 use chain;
 
 /// Amino messages which are signable within a Tendermint network
-pub trait SignableMsg: Debug {
+pub trait SignableMsg {
     /// Sign this message as bytes
     fn sign_bytes<B: BufMut>(
         &self,
@@ -16,6 +17,8 @@ pub trait SignableMsg: Debug {
 
     /// Set the Ed25519 signature on the underlying message
     fn set_signature(&mut self, sig: &ed25519::Signature);
+
+    fn validate(&self) -> Result<(), ValidationError>;
 }
 
 /// Signed message types. This follows:
@@ -50,15 +53,6 @@ impl SignedMsgType {
             0x02 => Ok(SignedMsgType::PreCommit),
             0x20 => Ok(SignedMsgType::Proposal),
             _ => Err(DecodeError::new("Invalid vote type")),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn is_valid_vote_type(msg_type: SignedMsgType) -> bool {
-        match msg_type {
-            SignedMsgType::PreVote => true,
-            SignedMsgType::PreCommit => true,
-            _ => false,
         }
     }
 }

--- a/tendermint-rs/src/amino_types/validate.rs
+++ b/tendermint-rs/src/amino_types/validate.rs
@@ -1,0 +1,31 @@
+pub trait ConsensusMessage {
+    fn validate_basic(&self) -> Result<(), ValidationError>;
+}
+
+pub struct ValidationError(ValidationErrorKind);
+
+impl ValidationError {
+    pub fn new(kind: ValidationErrorKind) -> ValidationError {
+        ValidationError(kind)
+    }
+}
+
+/// Kinds of validation errors
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum ValidationErrorKind {
+    #[fail(display = "invalid Type")]
+    InvalidMessageType,
+    #[fail(display = "negative height")]
+    NegativeHeight,
+    #[fail(display = "negative round")]
+    NegativeRound,
+    #[fail(display = "negative POLRound (exception: -1)")]
+    NegativePOLRound,
+    // TODO validate block ID
+}
+
+impl ToString for ValidationError {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}

--- a/tendermint-rs/src/amino_types/validate.rs
+++ b/tendermint-rs/src/amino_types/validate.rs
@@ -4,12 +4,6 @@ pub trait ConsensusMessage {
 
 pub struct ValidationError(ValidationErrorKind);
 
-impl ValidationError {
-    pub fn new(kind: ValidationErrorKind) -> ValidationError {
-        ValidationError(kind)
-    }
-}
-
 /// Kinds of validation errors
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
 pub enum ValidationErrorKind {
@@ -38,5 +32,11 @@ pub enum ValidationErrorKind {
 impl ToString for ValidationError {
     fn to_string(&self) -> String {
         self.0.to_string()
+    }
+}
+
+impl From<ValidationErrorKind> for ValidationError {
+    fn from(kind: ValidationErrorKind) -> Self {
+        ValidationError(kind)
     }
 }

--- a/tendermint-rs/src/amino_types/validate.rs
+++ b/tendermint-rs/src/amino_types/validate.rs
@@ -15,12 +15,18 @@ impl ValidationError {
 pub enum ValidationErrorKind {
     #[fail(display = "invalid Type")]
     InvalidMessageType,
+    #[fail(display = "consensus message is missing")]
+    MissingConsensusMessage,
     #[fail(display = "negative height")]
     NegativeHeight,
     #[fail(display = "negative round")]
     NegativeRound,
     #[fail(display = "negative POLRound (exception: -1)")]
     NegativePOLRound,
+    #[fail(display = "negative ValidatorIndex")]
+    NegativeValidatorIndex,
+    #[fail(display = "expected ValidatorAddress size to be 20 bytes")]
+    InvalidValidatorAddressSize,
     // TODO validate block ID
 }
 

--- a/tendermint-rs/src/amino_types/validate.rs
+++ b/tendermint-rs/src/amino_types/validate.rs
@@ -27,7 +27,12 @@ pub enum ValidationErrorKind {
     NegativeValidatorIndex,
     #[fail(display = "expected ValidatorAddress size to be 20 bytes")]
     InvalidValidatorAddressSize,
-    // TODO validate block ID
+    #[fail(display = "Wrong hash: expected Hash size to be 32 bytes")]
+    InvalidHashSize,
+    #[fail(display = "negative total")]
+    NegativeTotal,
+    #[fail(display = "missing blockId")]
+    MissingBlockId,
 }
 
 impl ToString for ValidationError {

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -7,10 +7,14 @@ use super::{
     remote_error::RemoteError,
     signature::SignableMsg,
     time::TimeMsg,
+    validate::{ConsensusMessage, ValidationError, ValidationErrorKind},
+    SignedMsgType,
 };
 use block;
 use chain;
 use error::Error;
+
+const VALIDATOR_ADDR_SIZE: usize = 20;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Vote {
@@ -30,6 +34,13 @@ pub struct Vote {
     pub validator_index: i64,
     #[prost(bytes)]
     pub signature: Vec<u8>,
+}
+
+impl Vote {
+    fn is_valid_vote_type(&self) -> bool {
+        self.vote_type == SignedMsgType::PreVote.to_u32()
+            || self.vote_type == SignedMsgType::PreCommit.to_u32()
+    }
 }
 
 impl block::ParseHeight for Vote {
@@ -135,6 +146,46 @@ impl SignableMsg for SignVoteRequest {
         if let Some(ref mut vt) = self.vote {
             vt.signature = sig.clone().into_vec();
         }
+    }
+    fn validate(&self) -> Result<(), ValidationError> {
+        match self.vote {
+            Some(ref v) => v.validate_basic(),
+            None => Err(ValidationError::new(
+                ValidationErrorKind::MissingConsensusMessage,
+            )),
+        }
+    }
+}
+
+impl ConsensusMessage for Vote {
+    fn validate_basic(&self) -> Result<(), ValidationError> {
+        if !self.is_valid_vote_type() {
+            return Err(ValidationError::new(
+                ValidationErrorKind::InvalidMessageType,
+            ));
+        }
+        if self.height < 0 {
+            return Err(ValidationError::new(ValidationErrorKind::NegativeHeight));
+        }
+        if self.round < 0 {
+            return Err(ValidationError::new(ValidationErrorKind::NegativeRound));
+        }
+        if self.validator_index < 0 {
+            return Err(ValidationError::new(
+                ValidationErrorKind::NegativeValidatorIndex,
+            ));
+        }
+        if self.validator_address.len() != VALIDATOR_ADDR_SIZE {
+            return Err(ValidationError::new(
+                ValidationErrorKind::InvalidValidatorAddressSize,
+            ));
+        }
+
+        // TODO validate votes's block_id
+
+        // signature will be missing as the KMS provides it
+
+        Ok(())
     }
 }
 

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -180,12 +180,11 @@ impl ConsensusMessage for Vote {
                 ValidationErrorKind::InvalidValidatorAddressSize,
             ));
         }
-
-        // TODO validate votes's block_id
-
+        match self.block_id {
+            Some(ref bid) => bid.validate_basic(),
+            None => Err(ValidationError::new(ValidationErrorKind::MissingBlockId)),
+        }
         // signature will be missing as the KMS provides it
-
-        Ok(())
     }
 }
 

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -150,9 +150,7 @@ impl SignableMsg for SignVoteRequest {
     fn validate(&self) -> Result<(), ValidationError> {
         match self.vote {
             Some(ref v) => v.validate_basic(),
-            None => Err(ValidationError::new(
-                ValidationErrorKind::MissingConsensusMessage,
-            )),
+            None => Err(ValidationErrorKind::MissingConsensusMessage.into()),
         }
     }
 }
@@ -160,29 +158,23 @@ impl SignableMsg for SignVoteRequest {
 impl ConsensusMessage for Vote {
     fn validate_basic(&self) -> Result<(), ValidationError> {
         if !self.is_valid_vote_type() {
-            return Err(ValidationError::new(
-                ValidationErrorKind::InvalidMessageType,
-            ));
+            return Err(ValidationErrorKind::InvalidMessageType.into());
         }
         if self.height < 0 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativeHeight));
+            return Err(ValidationErrorKind::NegativeHeight.into());
         }
         if self.round < 0 {
-            return Err(ValidationError::new(ValidationErrorKind::NegativeRound));
+            return Err(ValidationErrorKind::NegativeRound.into());
         }
         if self.validator_index < 0 {
-            return Err(ValidationError::new(
-                ValidationErrorKind::NegativeValidatorIndex,
-            ));
+            return Err(ValidationErrorKind::NegativeValidatorIndex.into());
         }
         if self.validator_address.len() != VALIDATOR_ADDR_SIZE {
-            return Err(ValidationError::new(
-                ValidationErrorKind::InvalidValidatorAddressSize,
-            ));
+            return Err(ValidationErrorKind::InvalidValidatorAddressSize.into());
         }
         match self.block_id {
             Some(ref bid) => bid.validate_basic(),
-            None => Err(ValidationError::new(ValidationErrorKind::MissingBlockId)),
+            None => Err(ValidationErrorKind::MissingBlockId.into()),
         }
         // signature will be missing as the KMS provides it
     }

--- a/tendermint-rs/src/secret_connection/mod.rs
+++ b/tendermint-rs/src/secret_connection/mod.rs
@@ -188,7 +188,7 @@ where
         }
 
         let mut sealed_frame = [0u8; TAG_SIZE + TOTAL_FRAME_SIZE];
-        self.io_handler.read_exact(&mut sealed_frame).unwrap();
+        self.io_handler.read_exact(&mut sealed_frame)?;
 
         // decrypt the frame
         let mut frame = [0u8; TOTAL_FRAME_SIZE];

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -383,10 +383,10 @@ fn test_handle_and_sign_vote() {
             timestamp: Some(t),
             vote_type: 0x01,
             block_id: Some(BlockId {
-                hash: "hash".as_bytes().to_vec(),
+                hash: b"some hash00000000000000000000000".to_vec(),
                 parts_header: Some(PartsSetHeader {
                     total: 1000000,
-                    hash: "parts_hash".as_bytes().to_vec(),
+                    hash: b"parts_hash0000000000000000000000".to_vec(),
                 }),
             }),
             signature: vec![],

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -373,15 +373,10 @@ fn test_handle_and_sign_vote() {
 
     ProtocolTester::apply(|mut pt| {
         let vote_msg = amino_types::vote::Vote {
-            validator_address: vec![
-                0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
-                0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
-            ],
-            validator_index: 56789,
+            vote_type: 0x01,
             height: 12345,
             round: 2,
             timestamp: Some(t),
-            vote_type: 0x01,
             block_id: Some(BlockId {
                 hash: b"some hash00000000000000000000000".to_vec(),
                 parts_header: Some(PartsSetHeader {
@@ -389,6 +384,11 @@ fn test_handle_and_sign_vote() {
                     hash: b"parts_hash0000000000000000000000".to_vec(),
                 }),
             }),
+            validator_address: vec![
+                0xa3, 0xb2, 0xcc, 0xdd, 0x71, 0x86, 0xf1, 0x68, 0x5f, 0x21, 0xf2, 0x48, 0x2a, 0xf4,
+                0xfb, 0x34, 0x46, 0xa8, 0x4b, 0x35,
+            ],
+            validator_index: 56789,
             signature: vec![],
         };
 


### PR DESCRIPTION
- implement basic validation logic to fix #81 
- additionally fix a decoding issue in Request::read (see https://github.com/tendermint/kms/pull/110/commits/bf304dcb7c2ee8b8e2bbcfb1d81b288fea3c77f6)