### PR TITLE
Dockerfile: Add Signatory dependencies (libudev, libsodium, libclang)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/tmkms:2018-11-26-v0 # bump cache keys when modifying this
+    - image: iqlusion/tmkms:2018-11-27-v4 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2018-11-26-v0 # bump save_cache key below too
+        key: cache-2018-11-27-v4 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -48,7 +48,7 @@ jobs:
           cargo audit --version
           cargo audit
     - save_cache:
-        key: cache-2018-11-26-v0 # bump restore_cache key above too
+        key: cache-2018-11-27-v4 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,28 @@
 # Tendermint KMS Dockerfile
 
-FROM centos:7.5.1804
+FROM centos:7
 
 # Install/update RPMs
 RUN yum update -y && \
     yum groupinstall -y "Development Tools" && \
-    yum install -y libusbx-devel openssl-devel sudo && \
+    yum install -y \
+        centos-release-scl \
+        cmake \
+        epel-release \
+        libudev-devel \
+        libusbx-devel \
+        openssl-devel \
+        sudo && \
+    yum install -y --enablerepo=epel libsodium-devel && \
+    yum install -y --enablerepo=centos-sclo-rh llvm-toolset-7 && \
     yum clean all && \
     rm -rf /var/cache/yum
+
+# Set environment variables to enable SCL packages (llvm-toolset-7)
+ENV LD_LIBRARY_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64
+ENV PATH "/opt/rh/llvm-toolset-7/root/usr/bin:/opt/rh/llvm-toolset-7/root/usr/sbin:$PATH"
+ENV PKG_CONFIG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/pkgconfig
+ENV X_SCLS llvm-toolset-7
 
 # Create "developer" user
 RUN useradd developer && \


### PR DESCRIPTION
I'm moving Signatory over to use this container image for CircleCI.

This is needed to test the Ledger provider, and will be needed in `tmkms` as well for testing a (future) Ledger backend.