### PR TITLE
tendermint.rs v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,7 +915,7 @@ dependencies = [
  "signatory-yubihsm 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.1.2",
+ "tendermint 0.1.3",
 ]
 
 [[package]]

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,7 @@
+## 0.1.3 (2018-12-01)
+
+- Prefix bech32 encoding of consensus keys with amino prefix (#128)
+
 ## 0.1.2 (2018-11-27)
 
 - Update to subtle-encoding v0.3 (#124)

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.1.2" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.1.3" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -18,7 +18,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.1.2"
+    html_root_url = "https://docs.rs/tendermint/0.1.3"
 )]
 
 #[cfg(feature = "secret-connection")]


### PR DESCRIPTION
- Prefix bech32 encoding of consensus keys with amino prefix (#128)
