### PR TITLE
Allow empty BlockIds in validation method

### DIFF
--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -25,7 +25,6 @@ impl ConsensusMessage for BlockId {
         if !self.hash.is_empty() && self.hash.len() != SHA256_HASH_SIZE {
             return Err(InvalidHashSize.into());
         }
-        // TODO: is an empty PartsSetHeader really OK here?
         self.parts_header
             .as_ref()
             .map_or(Ok(()), |psh| psh.validate_basic())

--- a/tendermint-rs/src/amino_types/validate.rs
+++ b/tendermint-rs/src/amino_types/validate.rs
@@ -25,8 +25,6 @@ pub enum ValidationErrorKind {
     InvalidHashSize,
     #[fail(display = "negative total")]
     NegativeTotal,
-    #[fail(display = "missing blockId")]
-    MissingBlockId,
 }
 
 impl ToString for ValidationError {

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -172,10 +172,10 @@ impl ConsensusMessage for Vote {
         if self.validator_address.len() != VALIDATOR_ADDR_SIZE {
             return Err(InvalidValidatorAddressSize.into());
         }
-        match self.block_id {
-            Some(ref bid) => bid.validate_basic(),
-            None => Err(MissingBlockId.into()),
+        if let Some(ref bid) = self.block_id {
+            return bid.validate_basic();
         }
+        Ok(())
         // signature will be missing as the KMS provides it
     }
 }

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -172,10 +172,11 @@ impl ConsensusMessage for Vote {
         if self.validator_address.len() != VALIDATOR_ADDR_SIZE {
             return Err(InvalidValidatorAddressSize.into());
         }
-        if let Some(ref bid) = self.block_id {
-            return bid.validate_basic();
-        }
-        Ok(())
+
+        self.block_id
+            .as_ref()
+            .map_or(Ok(()), |bid| bid.validate_basic())
+
         // signature will be missing as the KMS provides it
     }
 }


### PR DESCRIPTION
Fix #130 
copied from: https://github.com/tendermint/kms/issues/130#issuecomment-443480820
> Do we sign a message without a blockid when we vote nil?
> Yep, we sign BlockID{nil, PartSetHeader{}}, which encodes as [], so it's empty in the vote.