### PR TITLE
Update tmkms.toml.example

### DIFF
--- a/tmkms.toml.example
+++ b/tmkms.toml.example
@@ -1,6 +1,6 @@
 # Example KMS configuration file
 #
-# Copy this to 'kms.toml' and edit for your own purposes
+# Copy this to 'tmkms.toml' and edit for your own purposes
 
 [[validator]]
 addr = "tcp://example1.example.com:26658" # or "unix:///path/to/socket"


### PR DESCRIPTION
got `error: tmkms fatal error: config error: invalid path 'tmkms.toml': No such file or directory (os error 2)` because i named the file `kms.toml`. The error went away when I re-named to `tmkms.toml` per the docs everywhere else ;)