### PR TITLE
Lower reconnect delay to 1s

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -21,7 +21,7 @@ use keyring::SecretKeyEncoding;
 use session::Session;
 
 /// How long to wait after a crash before respawning (in seconds)
-pub const RESPAWN_DELAY: u64 = 5;
+pub const RESPAWN_DELAY: u64 = 1;
 
 /// Client connections: wraps a thread which makes a connection to a particular
 /// validator node and then receives RPCs.


### PR DESCRIPTION
gaiad times out slightly faster than tmkms is attempting to connect.

Ideally this value would be configurable, but for now we can lower it.