### PR TITLE
Migrate to rust 2018 edition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/tmkms:2018-11-27-v4 # bump cache keys when modifying this
+    - image: iqlusion/tmkms:2018-12-11-v0 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2018-11-27-v4 # bump save_cache key below too
+        key: cache-2018-12-11-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -48,7 +48,7 @@ jobs:
           cargo audit --version
           cargo audit
     - save_cache:
-        key: cache-2018-11-27-v4 # bump restore_cache key above too
+        key: cache-2018-12-11-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,8 @@ ENV PATH "$PATH:/home/developer/.cargo/bin"
 # Install rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
     rustup update && \
-    rustup component add rustfmt-preview && \
-    rustup component add clippy-preview && \
+    rustup component add rustfmt && \
+    rustup component add clippy && \
     cargo install cargo-audit
 
 # Configure Rust environment variables

--- a/src/application.rs
+++ b/src/application.rs
@@ -2,8 +2,8 @@
 
 use abscissa::{self, Application, LoggingConfig};
 
-use commands::KmsCommand;
-use config::KmsConfig;
+use crate::commands::KmsCommand;
+use crate::config::KmsConfig;
 
 /// The `tmkms` application
 #[derive(Debug)]

--- a/src/application.rs
+++ b/src/application.rs
@@ -2,8 +2,7 @@
 
 use abscissa::{self, Application, LoggingConfig};
 
-use crate::commands::KmsCommand;
-use crate::config::KmsConfig;
+use crate::{commands::KmsCommand, config::KmsConfig};
 
 /// The `tmkms` application
 #[derive(Debug)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,10 @@ use std::{
 };
 use tendermint::{chain, public_keys::SecretConnectionKey};
 
-use config::{ValidatorAddr, ValidatorConfig};
-use error::{KmsError, KmsErrorKind};
-use keyring::SecretKeyEncoding;
-use session::Session;
+use crate::config::{ValidatorAddr, ValidatorConfig};
+use crate::error::{KmsError, KmsErrorKind};
+use crate::keyring::SecretKeyEncoding;
+use crate::session::Session;
 
 /// How long to wait after a crash before respawning (in seconds)
 pub const RESPAWN_DELAY: u64 = 1;
@@ -112,7 +112,8 @@ fn tcp_session(
         );
 
         session.request_loop()
-    }).unwrap_or_else(|ref e| Err(KmsError::from_panic(e)))
+    })
+    .unwrap_or_else(|ref e| Err(KmsError::from_panic(e)))
 }
 
 /// Create a validator session over a Unix domain socket
@@ -127,7 +128,8 @@ fn unix_session(chain_id: chain::Id, socket_path: &Path) -> Result<(), KmsError>
         );
 
         session.request_loop()
-    }).unwrap_or_else(|ref e| Err(KmsError::from_panic(e)))
+    })
+    .unwrap_or_else(|ref e| Err(KmsError::from_panic(e)))
 }
 
 /// Initialize KMS secret connection private key

--- a/src/client.rs
+++ b/src/client.rs
@@ -15,10 +15,12 @@ use std::{
 };
 use tendermint::{chain, public_keys::SecretConnectionKey};
 
-use crate::config::{ValidatorAddr, ValidatorConfig};
-use crate::error::{KmsError, KmsErrorKind};
-use crate::keyring::SecretKeyEncoding;
-use crate::session::Session;
+use crate::{
+    config::{ValidatorAddr, ValidatorConfig},
+    error::{KmsError, KmsErrorKind},
+    keyring::SecretKeyEncoding,
+    session::Session,
+};
 
 /// How long to wait after a crash before respawning (in seconds)
 pub const RESPAWN_DELAY: u64 = 1;

--- a/src/commands/keygen.rs
+++ b/src/commands/keygen.rs
@@ -1,5 +1,5 @@
+use crate::keyring::SecretKeyEncoding;
 use abscissa::Callable;
-use keyring::SecretKeyEncoding;
 use signatory::{ed25519, Encode};
 use std::{env, process};
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,7 +17,7 @@ pub use self::yubihsm::YubihsmCommand;
 pub use self::{
     help::HelpCommand, keygen::KeygenCommand, start::StartCommand, version::VersionCommand,
 };
-use config::{KmsConfig, CONFIG_FILE_NAME};
+use crate::config::{KmsConfig, CONFIG_FILE_NAME};
 
 /// Subcommands of the KMS command-line application
 #[derive(Debug, Options)]

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,9 +1,9 @@
 use abscissa::{Callable, GlobalConfig};
 use std::process;
 
-use client::Client;
-use config::{KmsConfig, ValidatorConfig};
-use keyring::KeyRing;
+use crate::client::Client;
+use crate::config::{KmsConfig, ValidatorConfig};
+use crate::keyring::KeyRing;
 
 /// The `start` command
 #[derive(Debug, Options)]

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,9 +1,11 @@
 use abscissa::{Callable, GlobalConfig};
 use std::process;
 
-use crate::client::Client;
-use crate::config::{KmsConfig, ValidatorConfig};
-use crate::keyring::KeyRing;
+use crate::{
+    client::Client,
+    config::{KmsConfig, ValidatorConfig},
+    keyring::KeyRing,
+};
 
 /// The `start` command
 #[derive(Debug, Options)]

--- a/src/commands/yubihsm/detect.rs
+++ b/src/commands/yubihsm/detect.rs
@@ -1,7 +1,7 @@
 use abscissa::Callable;
 use std::process;
 
-use yubihsm::connector::usb::Devices;
+use crate::yubihsm::connector::usb::Devices;
 
 /// The `yubihsm detect` subcommand
 #[derive(Debug, Default, Options)]

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -34,17 +34,14 @@ impl Callable for GenerateCommand {
             process::exit(1);
         }
 
-        match &self.key_type {
-            Some(ref key_type) => {
-                if key_type != DEFAULT_KEY_TYPE {
-                    status_err!(
-                        "only supported key type is: ed25519 (given: \"{}\")",
-                        key_type
-                    );
-                    process::exit(1);
-                }
+        if let Some(key_type) = self.key_type.as_ref() {
+            if key_type != DEFAULT_KEY_TYPE {
+                status_err!(
+                    "only supported key type is: ed25519 (given: \"{}\")",
+                    key_type
+                );
+                process::exit(1);
             }
-            None => (),
         }
 
         let mut hsm = yubihsm::get_hsm_client();

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -2,9 +2,9 @@ use abscissa::Callable;
 use std::process;
 
 use super::*;
+use crate::yubihsm;
 use signatory::ed25519;
 use tendermint::public_keys::ConsensusKey;
-use yubihsm;
 
 /// The `yubihsm keys generate` subcommand
 #[derive(Debug, Default, Options)]
@@ -35,13 +35,15 @@ impl Callable for GenerateCommand {
         }
 
         match &self.key_type {
-            Some(ref key_type) => if key_type != DEFAULT_KEY_TYPE {
-                status_err!(
-                    "only supported key type is: ed25519 (given: \"{}\")",
-                    key_type
-                );
-                process::exit(1);
-            },
+            Some(ref key_type) => {
+                if key_type != DEFAULT_KEY_TYPE {
+                    status_err!(
+                        "only supported key type is: ed25519 (given: \"{}\")",
+                        key_type
+                    );
+                    process::exit(1);
+                }
+            }
             None => (),
         }
 
@@ -66,7 +68,8 @@ impl Callable for GenerateCommand {
                 ed25519::PublicKey::from_bytes(hsm.get_pubkey(*key_id).unwrap_or_else(|e| {
                     status_err!("couldn't get public key for key #{}: {}", key_id, e);
                     process::exit(1);
-                })).unwrap();
+                }))
+                .unwrap();
 
             status_ok!(
                 "Generated",

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -7,12 +7,12 @@ use std::io::prelude::*;
 use std::process;
 use std::str;
 
+use crate::yubihsm;
 use abscissa::Callable;
 use signatory::ed25519;
 use signatory::ed25519::Seed;
 use subtle_encoding::base64;
 use tendermint::public_keys::ConsensusKey;
-use yubihsm;
 
 use serde_json::Value;
 
@@ -53,13 +53,15 @@ impl Callable for ImportCommand {
         }
 
         match &self.key_type {
-            Some(ref key_type) => if key_type != DEFAULT_KEY_TYPE {
-                status_err!(
-                    "only supported key type is: ed25519 (given: \"{}\")",
-                    key_type
-                );
-                process::exit(1);
-            },
+            Some(ref key_type) => {
+                if key_type != DEFAULT_KEY_TYPE {
+                    status_err!(
+                        "only supported key type is: ed25519 (given: \"{}\")",
+                        key_type
+                    );
+                    process::exit(1);
+                }
+            }
             None => (),
         }
 
@@ -115,7 +117,8 @@ impl Callable for ImportCommand {
                     );
                     process::exit(1);
                 }),
-            ).unwrap();
+            )
+            .unwrap();
 
             status_ok!(
                 "Imported",

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,9 +1,9 @@
 use abscissa::Callable;
 use std::process;
 
+use crate::yubihsm;
 use signatory::ed25519;
 use tendermint::public_keys::ConsensusKey;
-use yubihsm;
 
 /// The `yubihsm keys list` subcommand
 #[derive(Debug, Default, Options)]

--- a/src/commands/yubihsm/keys/mod.rs
+++ b/src/commands/yubihsm/keys/mod.rs
@@ -3,8 +3,8 @@ mod help;
 mod import;
 mod list;
 
+use crate::yubihsm;
 use abscissa::Callable;
-use yubihsm;
 
 use self::{
     generate::GenerateCommand, help::HelpCommand, import::ImportCommand, list::ListCommand,

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,9 +1,9 @@
+use crate::yubihsm;
 use abscissa::Callable;
 use std::{
     thread,
     time::{Duration, Instant},
 };
-use yubihsm;
 
 // TODO: figure out rough size of the proposal amino message for testing
 const TEST_MESSAGE: &[u8; 128] = &[0u8; 128];

--- a/src/config/provider/yubihsm.rs
+++ b/src/config/provider/yubihsm.rs
@@ -1,11 +1,11 @@
 //! Configuration for the `YubiHSM` backend
 
+use crate::yubihsm::{Credentials, HttpConfig, SerialNumber, UsbConfig};
 use abscissa::{
     secrets::{BorrowSecret, DebugSecret, Secret},
     util::Zeroize,
 };
 use std::process;
-use yubihsm::{Credentials, HttpConfig, SerialNumber, UsbConfig};
 
 /// The (optional) `[providers.yubihsm]` config section
 #[derive(Clone, Deserialize, Debug)]

--- a/src/config/validator/addr.rs
+++ b/src/config/validator/addr.rs
@@ -7,7 +7,7 @@ use std::{
     str::{self, FromStr},
 };
 
-use error::{KmsError, KmsErrorKind::*};
+use crate::error::{KmsError, KmsErrorKind::*};
 
 #[derive(Clone, Debug)]
 pub enum ValidatorAddr {

--- a/src/config/validator/addr.rs
+++ b/src/config/validator/addr.rs
@@ -39,7 +39,7 @@ impl<'de> Deserialize<'de> for ValidatorAddr {
 }
 
 impl Display for ValidatorAddr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ValidatorAddr::Tcp { host, port, .. } => write!(f, "tcp://{}:{}", host, port),
             ValidatorAddr::Unix { socket_path } => write!(f, "unix://{}", socket_path.display()),

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,7 +20,7 @@ pub struct KmsError(Error<KmsErrorKind>);
 
 impl KmsError {
     /// Create an error from a panic
-    pub fn from_panic(msg: &Any) -> Self {
+    pub fn from_panic(msg: &dyn Any) -> Self {
         if let Some(e) = msg.downcast_ref::<String>() {
             err!(KmsErrorKind::PanicError, e)
         } else if let Some(e) = msg.downcast_ref::<&str>() {
@@ -82,7 +82,7 @@ pub enum KmsErrorKind {
 }
 
 impl Display for KmsError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,9 @@
 // Error types
 
+use crate::prost;
+#[cfg(feature = "yubihsm")]
+use crate::yubihsm;
 use abscissa::Error;
-use prost;
 use signatory;
 use std::{
     any::Any,
@@ -11,8 +13,6 @@ use std::{
 };
 use tendermint;
 use tendermint::amino_types::validate::ValidationError as TmValidationError;
-#[cfg(feature = "yubihsm")]
-use yubihsm;
 
 /// Error type
 #[derive(Debug)]
@@ -27,7 +27,8 @@ impl KmsError {
             err!(KmsErrorKind::PanicError, e)
         } else {
             err!(KmsErrorKind::PanicError, "unknown cause")
-        }.into()
+        }
+        .into()
     }
 }
 
@@ -150,7 +151,7 @@ impl From<TmValidationError> for KmsError {
 #[cfg(feature = "yubihsm")]
 impl From<yubihsm::connector::ConnectionError> for KmsError {
     fn from(other: yubihsm::connector::ConnectionError) -> Self {
-        use yubihsm::connector::ConnectionErrorKind;
+        use crate::yubihsm::connector::ConnectionErrorKind;
 
         let kind = match other.kind() {
             ConnectionErrorKind::AddrInvalid => KmsErrorKind::ConfigError,

--- a/src/keyring/ed25519/signer.rs
+++ b/src/keyring/ed25519/signer.rs
@@ -10,7 +10,7 @@ pub struct Signer {
     pub key_id: String,
 
     /// Signer trait object
-    provider: Box<SignerTrait<Signature>>,
+    provider: Box<dyn SignerTrait<Signature>>,
 }
 
 impl Signer {
@@ -18,7 +18,7 @@ impl Signer {
     pub fn new(
         provider_name: &'static str,
         key_id: String,
-        provider: Box<SignerTrait<Signature>>,
+        provider: Box<dyn SignerTrait<Signature>>,
     ) -> Self {
         Self {
             provider_name,

--- a/src/keyring/ed25519/signer.rs
+++ b/src/keyring/ed25519/signer.rs
@@ -1,4 +1,4 @@
-use error::{KmsError, KmsErrorKind::*};
+use crate::error::{KmsError, KmsErrorKind::*};
 use signatory::{self, ed25519::Signature, Signer as SignerTrait};
 
 /// Wrapper for an Ed25519 signing provider (i.e. trait object)

--- a/src/keyring/ed25519/softsign.rs
+++ b/src/keyring/ed25519/softsign.rs
@@ -6,9 +6,9 @@ use signatory_dalek::Ed25519Signer;
 use subtle_encoding::IDENTITY;
 
 use super::Signer;
-use config::provider::softsign::SoftSignConfig;
-use error::{KmsError, KmsErrorKind::*};
-use keyring::KeyRing;
+use crate::config::provider::softsign::SoftSignConfig;
+use crate::error::{KmsError, KmsErrorKind::*};
+use crate::keyring::KeyRing;
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum

--- a/src/keyring/ed25519/softsign.rs
+++ b/src/keyring/ed25519/softsign.rs
@@ -6,9 +6,11 @@ use signatory_dalek::Ed25519Signer;
 use subtle_encoding::IDENTITY;
 
 use super::Signer;
-use crate::config::provider::softsign::SoftSignConfig;
-use crate::error::{KmsError, KmsErrorKind::*};
-use crate::keyring::KeyRing;
+use crate::{
+    config::provider::softsign::SoftSignConfig,
+    error::{KmsError, KmsErrorKind::*},
+    keyring::KeyRing,
+};
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum

--- a/src/keyring/ed25519/yubihsm.rs
+++ b/src/keyring/ed25519/yubihsm.rs
@@ -3,9 +3,9 @@
 use signatory::PublicKeyed;
 use signatory_yubihsm::{self, KeyId};
 
-use config::provider::yubihsm::YubihsmConfig;
-use error::{KmsError, KmsErrorKind::*};
-use keyring::{ed25519::Signer, KeyRing};
+use crate::config::provider::yubihsm::YubihsmConfig;
+use crate::error::{KmsError, KmsErrorKind::*};
+use crate::keyring::{ed25519::Signer, KeyRing};
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum

--- a/src/keyring/ed25519/yubihsm.rs
+++ b/src/keyring/ed25519/yubihsm.rs
@@ -3,9 +3,11 @@
 use signatory::PublicKeyed;
 use signatory_yubihsm::{self, KeyId};
 
-use crate::config::provider::yubihsm::YubihsmConfig;
-use crate::error::{KmsError, KmsErrorKind::*};
-use crate::keyring::{ed25519::Signer, KeyRing};
+use crate::{
+    config::provider::yubihsm::YubihsmConfig,
+    error::{KmsError, KmsErrorKind::*},
+    keyring::{ed25519::Signer, KeyRing},
+};
 
 /// Label for ed25519-dalek provider
 // TODO: use a non-string type for these, e.g. an enum

--- a/src/keyring/mod.rs
+++ b/src/keyring/mod.rs
@@ -7,8 +7,10 @@ use std::{collections::BTreeMap, sync::RwLock};
 use subtle_encoding;
 use tendermint::public_keys::ConsensusKey;
 
-use crate::config::provider::ProviderConfig;
-use crate::error::{KmsError, KmsErrorKind::*};
+use crate::{
+    config::provider::ProviderConfig,
+    error::{KmsError, KmsErrorKind::*},
+};
 
 #[cfg(feature = "yubihsm")]
 use self::ed25519::yubihsm;

--- a/src/keyring/mod.rs
+++ b/src/keyring/mod.rs
@@ -7,8 +7,8 @@ use std::{collections::BTreeMap, sync::RwLock};
 use subtle_encoding;
 use tendermint::public_keys::ConsensusKey;
 
-use config::provider::ProviderConfig;
-use error::{KmsError, KmsErrorKind::*};
+use crate::config::provider::ProviderConfig;
+use crate::error::{KmsError, KmsErrorKind::*};
 
 #[cfg(feature = "yubihsm")]
 use self::ed25519::yubihsm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,5 +50,5 @@ mod unix_connection;
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
 
-pub use application::KmsApplication;
-pub use unix_connection::UnixConnection;
+pub use crate::application::KmsApplication;
+pub use crate::unix_connection::UnixConnection;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,12 @@ extern crate prost_amino as prost;
 extern crate abscissa;
 #[macro_use]
 extern crate abscissa_derive;
-extern crate byteorder;
 extern crate bytes;
-extern crate chrono;
 extern crate failure;
 #[macro_use]
 extern crate failure_derive;
 #[macro_use]
 extern crate lazy_static;
-extern crate rand;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,8 +1,8 @@
 //! Remote Procedure Calls
 
+use crate::prost::encoding::{decode_varint, encoded_len_varint};
+use crate::prost::Message;
 use bytes::IntoBuf;
-use prost::encoding::{decode_varint, encoded_len_varint};
-use prost::Message;
 use sha2::{Digest, Sha256};
 use std::io::Cursor;
 use std::io::{self, Read};

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,7 +1,10 @@
 //! Remote Procedure Calls
 
-use crate::prost::encoding::{decode_varint, encoded_len_varint};
-use crate::prost::Message;
+use crate::{
+    prost::encoding::{decode_varint, encoded_len_varint},
+    prost::Message,
+};
+
 use bytes::IntoBuf;
 use sha2::{Digest, Sha256};
 use std::io::Cursor;

--- a/src/session.rs
+++ b/src/session.rs
@@ -82,7 +82,7 @@ impl Session<UnixConnection<UnixStream>> {
             socket_path.to_str().unwrap()
         );
 
-        let connection = UnixConnection::new(socket)?;
+        let connection = UnixConnection::new(socket);
 
         Ok(Self {
             chain_id,

--- a/src/session.rs
+++ b/src/session.rs
@@ -15,14 +15,16 @@ use tendermint::{
     amino_types::{PingRequest, PingResponse, PubKeyMsg},
     chain,
     public_keys::SecretConnectionKey,
+    SecretConnection,
 };
 
-use crate::error::KmsError;
-use crate::keyring::KeyRing;
-use crate::prost::Message;
-use crate::rpc::{Request, Response, TendermintRequest};
-use crate::unix_connection::UnixConnection;
-use tendermint::SecretConnection;
+use crate::{
+    error::KmsError,
+    keyring::KeyRing,
+    prost::Message,
+    rpc::{Request, Response, TendermintRequest},
+    unix_connection::UnixConnection,
+};
 
 /// Encrypted session with a validator node
 pub struct Session<Connection> {

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,12 +17,12 @@ use tendermint::{
     public_keys::SecretConnectionKey,
 };
 
-use error::KmsError;
-use keyring::KeyRing;
-use prost::Message;
-use rpc::{Request, Response, TendermintRequest};
+use crate::error::KmsError;
+use crate::keyring::KeyRing;
+use crate::prost::Message;
+use crate::rpc::{Request, Response, TendermintRequest};
+use crate::unix_connection::UnixConnection;
 use tendermint::SecretConnection;
-use unix_connection::UnixConnection;
 
 /// Encrypted session with a validator node
 pub struct Session<Connection> {

--- a/src/unix_connection.rs
+++ b/src/unix_connection.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::marker::{Send, Sync};
 
-use error::KmsError;
+use crate::error::KmsError;
 
 /// Protocol implementation of the UNIX socket domain connection
 pub struct UnixConnection<IoHandler> {

--- a/src/unix_connection.rs
+++ b/src/unix_connection.rs
@@ -12,6 +12,7 @@ impl<IoHandler> UnixConnection<IoHandler>
 where
     IoHandler: io::Read + io::Write + Send + Sync,
 {
+    #[allow(clippy::new_ret_no_self)]
     /// Create a new `UnixConnection` for the given socket
     pub fn new(socket: IoHandler) -> Result<Self, KmsError> {
         Ok(Self { socket })

--- a/src/unix_connection.rs
+++ b/src/unix_connection.rs
@@ -1,8 +1,6 @@
 use std::io;
 use std::marker::{Send, Sync};
 
-use crate::error::KmsError;
-
 /// Protocol implementation of the UNIX socket domain connection
 pub struct UnixConnection<IoHandler> {
     socket: IoHandler,
@@ -12,10 +10,9 @@ impl<IoHandler> UnixConnection<IoHandler>
 where
     IoHandler: io::Read + io::Write + Send + Sync,
 {
-    #[allow(clippy::new_ret_no_self)]
     /// Create a new `UnixConnection` for the given socket
-    pub fn new(socket: IoHandler) -> Result<Self, KmsError> {
-        Ok(Self { socket })
+    pub fn new(socket: IoHandler) -> Self {
+        Self { socket }
     }
 }
 

--- a/src/yubihsm.rs
+++ b/src/yubihsm.rs
@@ -5,7 +5,7 @@ use std::{
     sync::{Mutex, MutexGuard},
 };
 
-use config::{provider::yubihsm::YubihsmConfig, KmsConfig};
+use crate::config::{provider::yubihsm::YubihsmConfig, KmsConfig};
 
 lazy_static! {
     static ref HSM_CLIENT: Mutex<Client> = Mutex::new(create_hsm_client());

--- a/src/yubihsm.rs
+++ b/src/yubihsm.rs
@@ -1,11 +1,13 @@
-use abscissa::GlobalConfig;
-pub use signatory_yubihsm::yubihsm::*;
-use std::{
-    process,
-    sync::{Mutex, MutexGuard},
+use crate::{
+    abscissa::GlobalConfig,
+    config::{provider::yubihsm::YubihsmConfig, KmsConfig},
+    std::{
+        process,
+        sync::{Mutex, MutexGuard},
+    },
 };
 
-use crate::config::{provider::yubihsm::YubihsmConfig, KmsConfig};
+pub use signatory_yubihsm::yubihsm::*;
 
 lazy_static! {
     static ref HSM_CLIENT: Mutex<Client> = Mutex::new(create_hsm_client());
@@ -45,7 +47,7 @@ pub fn get_config() -> YubihsmConfig {
 
 /// Open a session with the YubiHSM2 using settings from the global config
 #[cfg(not(feature = "yubihsm-mock"))]
-pub fn create_hsm_connector() -> Box<Connector> {
+pub fn create_hsm_connector() -> Box<dyn Connector> {
     // TODO: `HttpConnector` support
     let connector = UsbConnector::new(&get_config().usb_config()).unwrap_or_else(|e| {
         status_err!("error opening USB connection to YubiHSM2: {}", e);
@@ -56,7 +58,7 @@ pub fn create_hsm_connector() -> Box<Connector> {
 }
 
 #[cfg(feature = "yubihsm-mock")]
-pub fn create_hsm_connector() -> Box<Connector> {
+pub fn create_hsm_connector() -> Box<dyn Connector> {
     MOCK_HSM.clone().into()
 }
 

--- a/tendermint-rs/src/amino_types/block_id.rs
+++ b/tendermint-rs/src/amino_types/block_id.rs
@@ -1,8 +1,10 @@
 use super::validate::{ConsensusMessage, ValidationError, ValidationErrorKind::*};
-use algorithm::HashAlgorithm;
-use block;
-use error::Error;
-use hash::{Hash, SHA256_HASH_SIZE};
+use crate::{
+    algorithm::HashAlgorithm,
+    block,
+    error::Error,
+    hash::{Hash, SHA256_HASH_SIZE},
+};
 
 #[derive(Clone, PartialEq, Message)]
 pub struct BlockId {

--- a/tendermint-rs/src/amino_types/ed25519.rs
+++ b/tendermint-rs/src/amino_types/ed25519.rs
@@ -37,8 +37,7 @@ impl Into<PubKeyMsg> for PublicKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use prost::Message;
-    use std::error::Error;
+    use crate::{prost::Message, std::error::Error};
 
     #[test]
     fn test_empty_pubkey_msg() {

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -1,6 +1,11 @@
-use bytes::BufMut;
-use prost::{EncodeError, Message};
-use signatory::{ed25519, Signature};
+use crate::{
+    block,
+    bytes::BufMut,
+    chain,
+    error::Error,
+    prost::{EncodeError, Message},
+    signatory::{ed25519, Signature},
+};
 
 use super::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
@@ -9,9 +14,6 @@ use super::{
     time::TimeMsg,
     validate::{ConsensusMessage, ValidationError, ValidationErrorKind::*},
 };
-use block;
-use chain;
-use error::Error;
 
 #[derive(Clone, PartialEq, Message)]
 pub struct Proposal {
@@ -159,10 +161,12 @@ impl ConsensusMessage for Proposal {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amino_types::block_id::PartsSetHeader;
-    use chrono::{DateTime, Utc};
-    use prost::Message;
-    use std::error::Error;
+    use crate::{
+        amino_types::block_id::PartsSetHeader,
+        chrono::{DateTime, Utc},
+        prost::Message,
+        std::error::Error,
+    };
 
     #[test]
     fn test_serialization() {

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -190,7 +190,8 @@ mod tests {
 
         let _have = SignProposalRequest {
             proposal: Some(proposal),
-        }.encode(&mut got);
+        }
+        .encode(&mut got);
         // test-vector generated via:
         // cdc := amino.NewCodec()
         // privval.RegisterRemoteSignerMsg(cdc)

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -69,7 +69,7 @@ struct CanonicalProposal {
 
 impl chain::ParseId for CanonicalProposal {
     fn parse_chain_id(&self) -> Result<chain::Id, Error> {
-        chain::Id::new(&self.chain_id)
+        self.chain_id.parse()
     }
 }
 

--- a/tendermint-rs/src/amino_types/signature.rs
+++ b/tendermint-rs/src/amino_types/signature.rs
@@ -1,10 +1,10 @@
-use bytes::BufMut;
-use prost::{DecodeError, EncodeError};
-use signatory::ed25519;
-
-use amino_types::validate::ValidationError;
-
-use chain;
+use crate::{
+    amino_types::validate::ValidationError,
+    bytes::BufMut,
+    chain,
+    prost::{DecodeError, EncodeError},
+    signatory::ed25519,
+};
 
 /// Amino messages which are signable within a Tendermint network
 pub trait SignableMsg {

--- a/tendermint-rs/src/amino_types/time.rs
+++ b/tendermint-rs/src/amino_types/time.rs
@@ -1,10 +1,11 @@
 //! Timestamps
 
-use chrono::{TimeZone, Utc};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
-use error::Error;
-use timestamp::{ParseTimestamp, Timestamp};
+use crate::{
+    chrono::{TimeZone, Utc},
+    error::Error,
+    std::time::{Duration, SystemTime, UNIX_EPOCH},
+    timestamp::{ParseTimestamp, Timestamp},
+};
 
 #[derive(Clone, PartialEq, Message)]
 pub struct TimeMsg {

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -87,7 +87,7 @@ pub struct CanonicalVote {
 
 impl chain::ParseId for CanonicalVote {
     fn parse_chain_id(&self) -> Result<chain::Id, Error> {
-        chain::Id::new(&self.chain_id)
+        self.chain_id.parse()
     }
 }
 

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -1,6 +1,11 @@
-use bytes::BufMut;
-use prost::{error::EncodeError, Message};
-use signatory::{ed25519, Signature};
+use crate::{
+    block,
+    bytes::BufMut,
+    chain,
+    error::Error,
+    prost::{error::EncodeError, Message},
+    signatory::{ed25519, Signature},
+};
 
 use super::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
@@ -10,9 +15,6 @@ use super::{
     validate::{ConsensusMessage, ValidationError, ValidationErrorKind::*},
     SignedMsgType,
 };
-use block;
-use chain;
-use error::Error;
 
 const VALIDATOR_ADDR_SIZE: usize = 20;
 
@@ -185,9 +187,11 @@ impl ConsensusMessage for Vote {
 mod tests {
     use super::super::PartsSetHeader;
     use super::*;
-    use amino_types::SignedMsgType;
-    use chrono::{DateTime, Utc};
-    use prost::Message;
+    use crate::{
+        amino_types::SignedMsgType,
+        chrono::{DateTime, Utc},
+        prost::Message,
+    };
 
     #[test]
     fn test_vote_serialization() {

--- a/tendermint-rs/src/block/height.rs
+++ b/tendermint-rs/src/block/height.rs
@@ -1,6 +1,7 @@
-use std::fmt::{self, Debug, Display};
-
-use error::Error;
+use crate::{
+    error::Error,
+    std::fmt::{self, Debug, Display},
+};
 
 /// Block height for a particular chain (i.e. number of blocks created since
 /// the chain began)
@@ -30,13 +31,13 @@ impl Height {
 }
 
 impl Debug for Height {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "block::Height({})", self.0)
     }
 }
 
 impl Display for Height {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/tendermint-rs/src/block/id.rs
+++ b/tendermint-rs/src/block/id.rs
@@ -5,9 +5,7 @@ use std::{
     str::{self, FromStr},
 };
 
-use algorithm::HashAlgorithm;
-use error::Error;
-use hash::Hash;
+use crate::{algorithm::HashAlgorithm, error::Error, hash::Hash};
 
 /// Block identifiers
 #[derive(Clone, Debug, Hash, Eq, PartialEq)]
@@ -25,7 +23,7 @@ impl Id {
 
 // TODO: match gaia serialization? e.g `D2F5991B98D708FD2C25AA2BEBED9358F24177DE:1:C37A55FB95E9`
 impl Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", &self.hash)
     }
 }

--- a/tendermint-rs/src/chain/id.rs
+++ b/tendermint-rs/src/chain/id.rs
@@ -21,25 +21,6 @@ pub const MAX_LENGTH: usize = 50;
 pub struct Id([u8; MAX_LENGTH]);
 
 impl Id {
-    #[allow(clippy::new_ret_no_self)]
-    /// Create a new chain ID
-    pub fn new(name: &str) -> Result<Self, Error> {
-        if name.is_empty() || name.len() > MAX_LENGTH {
-            return Err(Error::Length);
-        }
-
-        for byte in name.as_bytes() {
-            match byte {
-                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' => (),
-                _ => return Err(Error::Parse),
-            }
-        }
-
-        let mut bytes = [0u8; MAX_LENGTH];
-        bytes[..name.as_bytes().len()].copy_from_slice(name.as_bytes());
-        Ok(Id(bytes))
-    }
-
     /// Get the chain ID as a `str`
     pub fn as_str(&self) -> &str {
         let byte_slice = match self.0.as_ref().iter().position(|b| *b == b'\0') {
@@ -79,9 +60,22 @@ impl<'a> From<&'a str> for Id {
 
 impl FromStr for Id {
     type Err = Error;
+    /// Parses string to create a new chain ID
+    fn from_str(name: &str) -> Result<Self, Error> {
+        if name.is_empty() || name.len() > MAX_LENGTH {
+            return Err(Error::Length);
+        }
 
-    fn from_str(s: &str) -> Result<Self, Error> {
-        Self::new(s)
+        for byte in name.as_bytes() {
+            match byte {
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' => (),
+                _ => return Err(Error::Parse),
+            }
+        }
+
+        let mut bytes = [0u8; MAX_LENGTH];
+        bytes[..name.as_bytes().len()].copy_from_slice(name.as_bytes());
+        Ok(Id(bytes))
     }
 }
 
@@ -141,22 +135,22 @@ mod tests {
     #[test]
     fn parses_valid_chain_ids() {
         assert_eq!(
-            Id::new(EXAMPLE_CHAIN_ID).unwrap().as_str(),
+            EXAMPLE_CHAIN_ID.parse::<Id>().unwrap().as_str(),
             EXAMPLE_CHAIN_ID
         );
 
         let long_id = String::from_utf8(vec![b'x'; MAX_LENGTH]).unwrap();
-        assert_eq!(Id::new(&long_id).unwrap().as_str(), &long_id);
+        assert_eq!(&long_id.parse::<Id>().unwrap().as_str(), &long_id);
     }
 
     #[test]
     fn rejects_empty_chain_ids() {
-        assert_eq!(Id::new(""), Err(Error::Length))
+        assert_eq!("".parse::<Id>(), Err(Error::Length))
     }
 
     #[test]
     fn rejects_overlength_chain_ids() {
         let overlong_id = String::from_utf8(vec![b'x'; MAX_LENGTH + 1]).unwrap();
-        assert_eq!(Id::new(&overlong_id), Err(Error::Length))
+        assert_eq!(overlong_id.parse::<Id>(), Err(Error::Length))
     }
 }

--- a/tendermint-rs/src/chain/id.rs
+++ b/tendermint-rs/src/chain/id.rs
@@ -9,7 +9,7 @@ use std::{
     str::{self, FromStr},
 };
 
-use error::Error;
+use crate::error::Error;
 
 /// Maximum length of a `chain::Id` name. Matches `MaxChainIDLen` from:
 /// <https://github.com/tendermint/tendermint/blob/develop/types/genesis.go>
@@ -29,7 +29,7 @@ impl Id {
 
         for byte in name.as_bytes() {
             match byte {
-                b'a'...b'z' | b'A'...b'Z' | b'0'...b'9' | b'-' | b'_' => (),
+                b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' => (),
                 _ => return Err(Error::Parse),
             }
         }
@@ -59,13 +59,13 @@ impl AsRef<str> for Id {
 }
 
 impl Debug for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "chain::Id({})", self.as_str())
     }
 }
 
 impl Display for Id {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }

--- a/tendermint-rs/src/chain/id.rs
+++ b/tendermint-rs/src/chain/id.rs
@@ -21,6 +21,7 @@ pub const MAX_LENGTH: usize = 50;
 pub struct Id([u8; MAX_LENGTH]);
 
 impl Id {
+    #[allow(clippy::new_ret_no_self)]
     /// Create a new chain ID
     pub fn new(name: &str) -> Result<Self, Error> {
         if name.is_empty() || name.len() > MAX_LENGTH {

--- a/tendermint-rs/src/chain/info.rs
+++ b/tendermint-rs/src/chain/info.rs
@@ -1,4 +1,4 @@
-use {block, chain, timestamp::Timestamp};
+use crate::{block, chain, timestamp::Timestamp};
 
 /// Information about a particular Tendermint blockchain
 #[derive(Clone, Debug)]

--- a/tendermint-rs/src/error.rs
+++ b/tendermint-rs/src/error.rs
@@ -1,12 +1,11 @@
 //! Error types
 
-use chrono;
 #[cfg(feature = "secret-connection")]
-use prost;
-#[cfg(feature = "secret-connection")]
-use signatory;
-use std::{self, io};
-use subtle_encoding;
+use crate::{
+    chrono, prost, signatory,
+    std::{self, io},
+    subtle_encoding,
+};
 
 /// Kinds of errors
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]

--- a/tendermint-rs/src/hash.rs
+++ b/tendermint-rs/src/hash.rs
@@ -18,6 +18,7 @@ pub enum Hash {
 }
 
 impl Hash {
+    #[allow(clippy::new_ret_no_self)]
     /// Create a new `Hash` with the given algorithm type
     pub fn new(alg: HashAlgorithm, bytes: &[u8]) -> Result<Hash, Error> {
         match alg {

--- a/tendermint-rs/src/hash.rs
+++ b/tendermint-rs/src/hash.rs
@@ -1,9 +1,11 @@
 //! Hash functions and their outputs
 
-use algorithm::HashAlgorithm;
-use error::Error;
-use std::fmt::{self, Display};
-use subtle_encoding::{Encoding, Hex};
+use crate::{
+    algorithm::HashAlgorithm,
+    error::Error,
+    std::fmt::{self, Display},
+    subtle_encoding::{Encoding, Hex},
+};
 
 /// Output size for the SHA-256 hash function
 pub const SHA256_HASH_SIZE: usize = 32;
@@ -57,7 +59,7 @@ impl AsRef<[u8]> for Hash {
 }
 
 impl Display for Hash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let hex = match self {
             Hash::Sha256(ref h) => Hex::upper_case().encode_to_string(h).unwrap(),
         };

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -62,12 +62,14 @@ pub mod public_keys;
 pub mod secret_connection;
 pub mod timestamp;
 
-pub use algorithm::*;
-pub use block::{ParseHeight as ParseBlockHeight, ParseId as ParseBlockId};
-pub use chain::ParseId as ParseChainId;
-pub use error::*;
-pub use hash::*;
-pub use public_keys::*;
 #[cfg(feature = "secret-connection")]
-pub use secret_connection::SecretConnection;
-pub use timestamp::*;
+pub use crate::secret_connection::SecretConnection;
+pub use crate::{
+    algorithm::*,
+    block::{ParseHeight as ParseBlockHeight, ParseId as ParseBlockId},
+    chain::ParseId as ParseChainId,
+    error::*,
+    hash::*,
+    public_keys::*,
+    timestamp::*,
+};

--- a/tendermint-rs/src/public_keys.rs
+++ b/tendermint-rs/src/public_keys.rs
@@ -1,12 +1,13 @@
 //! Public keys used in Tendermint networks
 // TODO:: account keys
 
-use sha2::{Digest, Sha256};
-use signatory::ed25519;
-use std::fmt::{self, Display};
-use subtle_encoding::bech32;
-
-use error::Error;
+use crate::{
+    error::Error,
+    sha2::{Digest, Sha256},
+    signatory::ed25519,
+    std::fmt::{self, Display},
+    subtle_encoding::bech32,
+};
 
 /// Validator signing keys used for authenticating consensus protocol messages
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq)]
@@ -32,7 +33,7 @@ impl ConsensusKey {
 }
 
 impl Display for ConsensusKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //Amino prefix for Pubkey
         let mut key_bytes: Vec<u8> = vec![0x16, 0x24, 0xDE, 0x64, 0x20];
         match self {
@@ -74,7 +75,7 @@ impl SecretConnectionKey {
 }
 
 impl Display for SecretConnectionKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SecretConnectionKey::Ed25519(ref pk) => {
                 for byte in &Sha256::digest(pk.as_bytes())[..20] {

--- a/tendermint-rs/src/public_keys.rs
+++ b/tendermint-rs/src/public_keys.rs
@@ -104,7 +104,8 @@ mod tests {
     fn test_address_serialization() {
         let example_key = SecretConnectionKey::from_raw_ed25519(
             &hex::decode_upper(EXAMPLE_SECRET_CONN_KEY).unwrap(),
-        ).unwrap();
+        )
+        .unwrap();
 
         assert_eq!(
             example_key.to_string(),

--- a/tendermint-rs/src/secret_connection/mod.rs
+++ b/tendermint-rs/src/secret_connection/mod.rs
@@ -130,7 +130,8 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
                 authtext,
                 0,
                 in_out,
-            ).map_err(|_| Error::Crypto)?
+            )
+            .map_err(|_| Error::Crypto)?
             .len();
             Ok(len)
         } else {
@@ -141,7 +142,8 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
                 authtext,
                 0,
                 &mut in_out,
-            ).map_err(|_| Error::Crypto)?;
+            )
+            .map_err(|_| Error::Crypto)?;
             out[..out0.len()].copy_from_slice(out0);
             Ok(out0.len())
         }
@@ -165,7 +167,8 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
             &[0u8; 0],
             sealed_frame,
             TAG_SIZE,
-        ).map_err(|_| Error::Crypto)?;
+        )
+        .map_err(|_| Error::Crypto)?;
 
         Ok(())
     }

--- a/tendermint-rs/src/secret_connection/mod.rs
+++ b/tendermint-rs/src/secret_connection/mod.rs
@@ -55,7 +55,7 @@ impl<IoHandler: Read + Write + Send + Sync> SecretConnection<IoHandler> {
     pub fn remote_pubkey(&self) -> SecretConnectionKey {
         self.remote_pubkey
     }
-
+    #[allow(clippy::new_ret_no_self)]
     /// Performs handshake and returns a new authenticated SecretConnection.
     pub fn new(
         mut handler: IoHandler,

--- a/tendermint-rs/src/timestamp.rs
+++ b/tendermint-rs/src/timestamp.rs
@@ -1,11 +1,12 @@
 //! Timestamps used by Tendermint blockchains
 
-use chrono::{DateTime, Utc};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
 #[cfg(feature = "tai64")]
-use tai64::TAI64N;
-
-use error::Error;
+use crate::tai64::TAI64N;
+use crate::{
+    chrono::{DateTime, Utc},
+    error::Error,
+    std::time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 /// Chain timestamps (e.g. consensus time)
 #[cfg_attr(feature = "serializers", derive(Serialize, Deserialize))]

--- a/tests/cli/yubihsm/detect.rs
+++ b/tests/cli/yubihsm/detect.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the `yubihsm detect` subcommand
 
-use cli;
+use crate::cli;
 
 #[test]
 fn detect_command_test() {

--- a/tests/cli/yubihsm/keys/generate.rs
+++ b/tests/cli/yubihsm/keys/generate.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the `yubihsm keys generate` subcommand
 
-use cli;
+use crate::cli;
 
 #[test]
 fn keys_generate_command_test() {

--- a/tests/cli/yubihsm/keys/import.rs
+++ b/tests/cli/yubihsm/keys/import.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the `yubihsm keys import` subcommand
 
-use cli;
+use crate::cli;
 
 #[test]
 fn keys_import_command_test() {

--- a/tests/cli/yubihsm/keys/list.rs
+++ b/tests/cli/yubihsm/keys/list.rs
@@ -1,6 +1,6 @@
 //! Integration tests for the `yubihsm keys list` subcommand
 
-use cli;
+use crate::cli;
 
 #[test]
 fn keys_command_test() {

--- a/tests/cli/yubihsm/keys/mod.rs
+++ b/tests/cli/yubihsm/keys/mod.rs
@@ -5,7 +5,7 @@ mod import;
 mod list;
 
 pub use super::{KMS_CONFIG_PATH, PRIV_VALIDATOR_CONFIG_PATH};
-use cli;
+use crate::cli;
 
 #[test]
 fn test_usage() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -203,7 +203,7 @@ impl KmsDevice {
             KmsSocket::UNIX(ref sock) => {
                 let socket_cp = sock.try_clone().unwrap();
 
-                KmsConnection::UNIXConnection(UnixConnection::new(socket_cp).unwrap())
+                KmsConnection::UNIXConnection(UnixConnection::new(socket_cp))
             }
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,8 +15,8 @@ extern crate sha2;
 extern crate tendermint;
 extern crate tmkms;
 
+use crate::prost::Message;
 use chrono::{DateTime, Utc};
-use prost::Message;
 use rand::Rng;
 use signatory::{ed25519, encoding::Identity, Decode, Signature};
 use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
@@ -435,7 +435,8 @@ fn test_handle_and_sign_get_publickey() {
 
         PubKeyMsg {
             pub_key_ed25519: vec![],
-        }.encode(&mut buf)
+        }
+        .encode(&mut buf)
         .unwrap();
 
         pt.write_all(&buf).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -157,7 +157,8 @@ impl KmsDevice {
             path = "{}"
         "#,
             port, SIGNING_KEY_PATH
-        );
+        )
+        .unwrap();
 
         config_file
     }
@@ -177,7 +178,8 @@ impl KmsDevice {
             path = "{}"
         "#,
             socket_path, SIGNING_KEY_PATH
-        );
+        )
+        .unwrap();
 
         config_file
     }


### PR DESCRIPTION
- [x] apply cargo fix --edition
- [x] manually remove most `extern crate foo;`s
- [x] use `dyn` keyword
 - [x] `use crate::` (absolute path)
 - [x] anonymous lifetimes
 - [x] inclusive ranges via `..=`
- [x] docker image used in circle-ci needs updating (thanks @tony-iqlusion!); current version: https://github.com/tendermint/kms/blob/ad0296ae5bbfb20f743faa9a86a81e4ddf2f42b6/.circleci/config.yml#L6