### PR TITLE
Refactor client/tests to always dial Tendermint

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -121,10 +121,10 @@ fn tcp_session(
 /// Create a validator session over a Unix domain socket
 fn unix_session(chain_id: chain::Id, socket_path: &Path) -> Result<(), KmsError> {
     panic::catch_unwind(move || {
-        let mut session = Session::accept_unix(chain_id, socket_path)?;
+        let mut session = Session::connect_unix(chain_id, socket_path)?;
 
         info!(
-            "[{}@unix://{}] waiting for a validator connection",
+            "[{}@unix://{}] connected to validator successfully",
             chain_id,
             socket_path.display()
         );

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,7 +21,7 @@ use rand::Rng;
 use signatory::{ed25519, encoding::Identity, Decode, Signature};
 use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 use std::io;
-use std::os::unix::net::{UnixStream, UnixListener};
+use std::os::unix::net::{UnixListener, UnixStream};
 use std::{
     io::{Cursor, Read, Write},
     net::{TcpListener, TcpStream},


### PR DESCRIPTION
Previously, when connecting via Unix socket, KMS would wait for
Tendermint to connect. This was different to the TCP connection, where
KMS would dial out to Tendermint via TCP socket.

This commit enables dialing out to Tendermint via Unix socket. This is as per #148 