### PR TITLE
tendermint-rs: v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -915,7 +915,7 @@ dependencies = [
  "signatory-yubihsm 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.1.4",
+ "tendermint 0.1.5",
 ]
 
 [[package]]

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,12 @@
+## 0.1.5 (2019-01-18)
+
+This release is compatible with tendermint [v0.28]
+
+- Split `PubKeyMsg` into `PubKeyRequest` and `PubKeyResponse` (#141)
+- Migrate to Rust 2018 edition (#138)
+
+[v0.28]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0280
+ 
 ## 0.1.4 (2018-12-02)
 
 - Allow empty BlockIds in validation method (#131)

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.1.4" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.1.5" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -18,7 +18,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.1.4"
+    html_root_url = "https://docs.rs/tendermint/0.1.5"
 )]
 
 #[cfg(feature = "secret-connection")]


### PR DESCRIPTION
see https://github.com/tendermint/kms/compare/tendermint-rs/v0.1.5?expand=1#diff-af123cab5dd97837859154a7c5ad3f25