### PR TITLE
Remove PoisonPillMsg

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -23,9 +23,6 @@ pub enum Request {
 
     // PingRequest is a PrivValidatorSocket message to keep the connection alive.
     ReplyPing(PingRequest),
-
-    /// Instruct the KMS to terminate
-    PoisonPill(PoisonPillMsg),
 }
 
 /// Responses from the KMS
@@ -62,7 +59,6 @@ fn compute_prefix(name: &str) -> (Vec<u8>) {
 // pre-compute registered types prefix (this is probably sth. our amino library should
 // provide instead)
 lazy_static! {
-    static ref PP_PREFIX: Vec<u8> = compute_prefix(POISON_PILL_AMINO_NAME);
     static ref VOTE_PREFIX: Vec<u8> = compute_prefix(VOTE_AMINO_NAME);
     static ref PROPOSAL_PREFIX: Vec<u8> = compute_prefix(PROPOSAL_AMINO_NAME);
     static ref PUBKEY_PREFIX: Vec<u8> = compute_prefix(PUBKEY_AMINO_NAME);
@@ -93,7 +89,6 @@ impl Request {
         let total_len = encoded_len_varint(len).checked_add(len as usize).unwrap();
         let rem = buff.get_ref()[..total_len].to_vec();
         match amino_pre {
-            ref pp if *pp == *PP_PREFIX => Ok(Request::PoisonPill(PoisonPillMsg {})),
             ref vt if *vt == *VOTE_PREFIX => Ok(Request::SignVote(SignVoteRequest::decode(&rem)?)),
             ref pr if *pr == *PROPOSAL_PREFIX => {
                 Ok(Request::SignProposal(SignProposalRequest::decode(&rem)?))

--- a/src/session.rs
+++ b/src/session.rs
@@ -84,9 +84,6 @@ where
     pub fn request_loop(&mut self, should_term: &Arc<AtomicBool>) -> Result<(), KmsError> {
         debug!("starting handle request loop ... ");
         while self.handle_request(should_term)? {}
-        // Only happens when we received a PoisonPillMsg, so tell the outer
-        // thread to terminate.
-        should_term.swap(true, Ordering::Relaxed);
         Ok(())
     }
 
@@ -103,7 +100,6 @@ where
             // non-signable requests:
             Request::ReplyPing(ref req) => self.reply_ping(req),
             Request::ShowPublicKey(ref req) => self.get_public_key(req)?,
-            Request::PoisonPill(_req) => return Ok(false),
         };
 
         let mut buf = vec![];

--- a/tendermint-rs/src/amino_types/mod.rs
+++ b/tendermint-rs/src/amino_types/mod.rs
@@ -6,7 +6,6 @@
 pub mod block_id;
 pub mod ed25519;
 pub mod ping;
-pub mod poisonpill;
 pub mod proposal;
 pub mod remote_error;
 pub mod secret_connection;
@@ -19,7 +18,6 @@ pub use self::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader, PartsSetHeader},
     ed25519::{PubKeyRequest, PubKeyResponse, AMINO_NAME as PUBKEY_AMINO_NAME},
     ping::{PingRequest, PingResponse, AMINO_NAME as PING_AMINO_NAME},
-    poisonpill::{PoisonPillMsg, AMINO_NAME as POISON_PILL_AMINO_NAME},
     proposal::{SignProposalRequest, SignedProposalResponse, AMINO_NAME as PROPOSAL_AMINO_NAME},
     remote_error::RemoteError,
     secret_connection::AuthSigMessage,

--- a/tendermint-rs/src/amino_types/poisonpill.rs
+++ b/tendermint-rs/src/amino_types/poisonpill.rs
@@ -1,5 +1,0 @@
-pub const AMINO_NAME: &str = "tendermint/kms/PoisonPillMsg";
-
-#[derive(Clone, PartialEq, Message)]
-#[amino_name = "tendermint/kms/PoisonPillMsg"]
-pub struct PoisonPillMsg {}


### PR DESCRIPTION
As per #161 we have other means to shut down gracefully. 

Note that that integration tests currently use `SIGKILL` to shut down the processes they've started. I couldn't find a way to send SIGINT in rust without adding another (dev) dependency. If we want an integration test for the sig_hook, or, let the tests use SIGINT (ctrl+c) instead of SIGKILL, we can do so by using `libc` I think. 