### PR TITLE
WIP: Add Tendermint test harness to KMS integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: tendermint/kms:build-2019-01-21-v0 # bump cache keys when modifying this
+    - image: tendermint/kms:build-2019-01-24-v0 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2019-01-21-v0 # bump save_cache key below too
+        key: cache-2019-01-24-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -52,7 +52,7 @@ jobs:
         command: |
           TMKMS_BIN=./target/debug/tmkms sh tests/support/run-harness-tests.sh
     - save_cache:
-        key: cache-2019-01-21-v0 # bump restore_cache key above too
+        key: cache-2019-01-24-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: iqlusion/tmkms:2018-12-11-v0 # bump cache keys when modifying this
+    - image: tendermint/kms:build-2019-01-21-v0 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2018-12-11-v0 # bump save_cache key below too
+        key: cache-2019-01-21-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -47,8 +47,12 @@ jobs:
         command: |
           cargo audit --version
           cargo audit
+    - run:
+        name: validate against test harness
+        command: |
+          TMKMS_BIN=./target/debug/tmkms sh tests/support/run-harness-tests.sh
     - save_cache:
-        key: cache-2018-12-11-v0 # bump restore_cache key above too
+        key: cache-2019-01-21-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,44 @@
+###################################################
+# Test harness for remote signer from Tendermint
+
+# Configure the version of Tendermint here against which you want to run
+# integration tests
+ARG TENDERMINT_VERSION=latest
+
+FROM tendermint/remote_val_harness:${TENDERMINT_VERSION} AS harness
+
+USER root
+
+RUN mkdir -p /remote_val_harness
+
+# We need this script to generate configuration for the KMS
+COPY tests/support/gen-validator-integration-cfg.sh /remote_val_harness/
+
+# Generate the base configuration data for the Tendermint validator for use
+# during integration testing. This will generate the data, by default, in the
+# /tendermint directory.
+RUN tendermint init --home=/remote_val_harness && \
+    remote_val_harness extract_key --tmhome=/remote_val_harness --output=/remote_val_harness/signing.key && \
+    cd /remote_val_harness && \
+    chmod +x gen-validator-integration-cfg.sh && \
+    TMHOME=/remote_val_harness sh ./gen-validator-integration-cfg.sh
+
+###################################################
 # Tendermint KMS Dockerfile
 
-FROM centos:7
+FROM centos:7 AS build
 
 # Install/update RPMs
 RUN yum update -y && \
     yum groupinstall -y "Development Tools" && \
     yum install -y \
-        centos-release-scl \
-        cmake \
-        epel-release \
-        libudev-devel \
-        libusbx-devel \
-        openssl-devel \
-        sudo && \
+    centos-release-scl \
+    cmake \
+    epel-release \
+    libudev-devel \
+    libusbx-devel \
+    openssl-devel \
+    sudo && \
     yum install -y --enablerepo=epel libsodium-devel && \
     yum install -y --enablerepo=centos-sclo-rh llvm-toolset-7 && \
     yum clean all && \
@@ -45,3 +71,20 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 # Configure Rust environment variables
 ENV RUSTFLAGS "-Ctarget-feature=+aes"
 ENV RUST_BACKTRACE full
+
+###################################################
+# Remote validator integration testing
+
+# We need the generated harness and Tendermint configuration
+COPY --from=harness /remote_val_harness /remote_val_harness
+
+# We need the test harness binary
+COPY --from=harness /usr/bin/remote_val_harness /usr/bin/remote_val_harness
+
+# We need a secret connection key
+COPY tests/support/secret_connection.key /remote_val_harness/
+
+USER root
+# Ensure the /remote_val_harness folder has the right owner
+RUN chown -R developer /remote_val_harness
+USER developer

--- a/tests/support/gen-validator-integration-cfg.sh
+++ b/tests/support/gen-validator-integration-cfg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+PWD=`pwd`
+TMHOME=${TMHOME:-${PWD}}
+OUTPUT_PATH=${OUTPUT_PATH:-${PWD}}
+GENESIS_FILE=${GENESIS_FILE:-${TMHOME}/config/genesis.json}
+SIGNING_KEY=${SIGNING_KEY:-${OUTPUT_PATH}/signing.key}
+SECRET_KEY=${SECRET_KEY:-${OUTPUT_PATH}/secret_connection.key}
+OUTPUT_FILE=${OUTPUT_FILE:-${OUTPUT_PATH}/tmkms.toml}
+VALIDATOR_ADDR=${VALIDATOR_ADDR:-"tcp://127.0.0.1:61278"}
+CFG_TEMPLATE=$(cat <<-EOF
+[[validator]]
+addr = "VALIDATOR_ADDR"
+chain_id = "CHAIN_ID"
+reconnect = true # true is the default
+secret_key = "SECRET_KEY"
+
+[[providers.softsign]]
+id = "CHAIN_ID"
+path = "SIGNING_KEY"
+EOF
+)
+
+# First extract the chain ID from the genesis file
+CHAIN_ID_SED_EXPR='s/[ ]*"chain_id":[ ]*"\([^"]*\)".*/\1/'
+CHAIN_ID=`grep '"chain_id"' ${GENESIS_FILE} | sed "${CHAIN_ID_SED_EXPR}"`
+
+# Now generate the tmkms.toml file
+echo "${CFG_TEMPLATE}" | \
+    sed "s|CHAIN_ID|${CHAIN_ID}|g" | \
+    sed "s|VALIDATOR_ADDR|${VALIDATOR_ADDR}|g" | \
+    sed "s|SECRET_KEY|${SECRET_KEY}|g" | \
+    sed "s|SIGNING_KEY|${SIGNING_KEY}|g" > ${OUTPUT_FILE}
+
+echo "Wrote ${OUTPUT_FILE}"

--- a/tests/support/run-harness-tests.sh
+++ b/tests/support/run-harness-tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+TMKMS_BIN=${TMKMS_BIN:-"./target/debug/tmkms"}
+TMKMS_CONFIG=${TMKMS_CONFIG:-"/remote_val_harness/tmkms.toml"}
+REMOTE_VAL_HARNESS_BIN=${REMOTE_VAL_HARNESS_BIN:-"remote_val_harness"}
+TMHOME=${TMHOME:-"/remote_val_harness"}
+
+# Run KMS in the background
+${TMKMS_BIN} start -c ${TMKMS_CONFIG} &
+TMKMS_PID=$!
+
+# Run the test harness in the foreground
+${REMOTE_VAL_HARNESS_BIN} run \
+    --addr tcp://127.0.0.1:61278 \
+    --genesis-file ${TMHOME}/config/genesis.json \
+    --key-file ${TMHOME}/config/priv_validator_key.json \
+    --state-file ${TMHOME}/data/priv_validator_state.json
+HARNESS_EXIT_CODE=$?
+
+# Kill the KMS, if it's still running
+if ps -p ${TMKMS_PID} > /dev/null
+then
+    echo "Killing KMS (pid ${TMKMS_PID})"
+    kill ${TMKMS_PID}
+else
+    echo "KMS (pid ${TMKMS_PID}) already stopped, not killing"
+fi
+
+# Bubble the exit code up out of the script
+echo "Harness tests exiting with code ${HARNESS_EXIT_CODE}"
+exit ${HARNESS_EXIT_CODE}


### PR DESCRIPTION
Relates to #49 - this PR will assist in performing integration tests between the KMS and Tendermint.

With this PR, CircleCI will pull a new base build image for the KMS that will also incorporate the remote validator test harness. See https://github.com/tendermint/tendermint/pull/3149

The new base build image is built from the `Dockerfile` in this PR.