### PR TITLE
Update for new version of remote_val_harness

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: tendermint/kms:build-2019-01-24-v0 # bump cache keys when modifying this
+    - image: tendermint/kms:build-2019-01-25-v0 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2019-01-24-v0 # bump save_cache key below too
+        key: cache-2019-01-25-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -52,7 +52,7 @@ jobs:
         command: |
           TMKMS_BIN=./target/debug/tmkms sh tests/support/run-harness-tests.sh
     - save_cache:
-        key: cache-2019-01-24-v0 # bump restore_cache key above too
+        key: cache-2019-01-25-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"

--- a/tests/support/run-harness-tests.sh
+++ b/tests/support/run-harness-tests.sh
@@ -10,10 +10,8 @@ TMKMS_PID=$!
 
 # Run the test harness in the foreground
 ${REMOTE_VAL_HARNESS_BIN} run \
-    --addr tcp://127.0.0.1:61278 \
-    --genesis-file ${TMHOME}/config/genesis.json \
-    --key-file ${TMHOME}/config/priv_validator_key.json \
-    --state-file ${TMHOME}/data/priv_validator_state.json
+    -addr tcp://127.0.0.1:61278 \
+    -tmhome ${TMHOME}
 HARNESS_EXIT_CODE=$?
 
 # Kill the KMS, if it's still running

--- a/tests/support/run-harness-tests.sh
+++ b/tests/support/run-harness-tests.sh
@@ -19,6 +19,16 @@ if ps -p ${TMKMS_PID} > /dev/null
 then
     echo "Killing KMS (pid ${TMKMS_PID})"
     kill ${TMKMS_PID}
+    # Wait a few seconds for KMS to die properly.
+    # NOTE: This also acts as a test of the KMS listening for and properly
+    # responding to the SIGTERM signal from `kill`.
+    sleep 3
+    # Make sure KMS has actually stopped properly now.
+    if ps -p ${TMKMS_PID} > /dev/null
+    then
+        echo "Failed to stop KMS!"
+        exit 100
+    fi
 else
     echo "KMS (pid ${TMKMS_PID}) already stopped, not killing"
 fi


### PR DESCRIPTION
This PR firstly changes the command line parameter format when calling `remote_val_harness`, since the latest changes to `remote_val_harness` use the Go `flag` library instead of `cobra`.

Secondly, it adds a check during the execution of the test harness to make sure that the KMS actually dies within 3 seconds of sending it a `SIGTERM` signal. (Ideally this should be a separate PR, but I thought I'd put it in here to save some review time).