### PR TITLE
yubihsm setup (closes #174)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,14 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +245,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,6 +390,15 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -478,6 +526,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +544,11 @@ dependencies = [
 [[package]]
 name = "matches"
 version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memoffset"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -503,6 +564,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "num-integer"
 version = "0.1.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,9 +582,46 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num_cpus"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "once_cell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "parking_lot"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -527,6 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -675,6 +779,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,8 +839,21 @@ version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ryu"
 version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -850,6 +988,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "spin"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,6 +1116,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-bip39"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tmkms"
 version = "0.3.0"
 dependencies = [
@@ -983,10 +1140,13 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -999,7 +1159,9 @@ dependencies = [
  "subtle-encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendermint 0.2.0",
+ "tiny-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.21.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1126,6 +1288,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1025aeae2b664ca0ea726a89d574fe8f4e77dd712d443236ad1de00379450cf6"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
+"checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
@@ -1148,6 +1311,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmac 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4a435124bcc292eba031f1f725d7abacdaf13cbf9f935450e8c45aa9e96cad"
+"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
+"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
+"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 "checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
 "checksum dbl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
@@ -1162,6 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum gaunt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0348d3b5fbd30311ea16ce573f137c689e5a3fb2d7b037eefe0a6384143298b6"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hidapi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1be4c25fc554bc65ace58feb1ae4aec1258dc822543a735b1f3bc7af06f84039"
 "checksum hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a89c4638cf4e02d9db29750659d2af13d9001b508716f77d4693ec8a1f8bda8"
@@ -1176,12 +1343,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)" = "413f3dfc802c5dc91dc570b05125b6cda9855edfaa9825c9849807876376e70e"
 "checksum libusb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f990ddd929cbe53de4ecd6cf26e1f4e0c5b9796e4c629d9046570b03738aa53"
 "checksum libusb-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c53b6582563d64ad3e692f54ef95239c3ea8069e82c9eb70ca948869a7ad767"
+"checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
+"checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
+"checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
+"checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
@@ -1199,12 +1373,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+"checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"
+"checksum rayon-core 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b055d1e92aba6877574d8fe604a63c8b5df60f60e5982bf7ccbb1338ea527356"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
+"checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -1219,6 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum signatory-ledger-tm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2633f1e0a241347d31f2031b6053506dd72d9c5dedf06fe231526f049e4d1ed"
 "checksum signatory-secp256k1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57765ca2c5615453b345477546ddc697921f3c8fc71fd1ffc4edc2ffa0453f1d"
 "checksum simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e95345f185d5adeb8ec93459d2dc99654e294cc6ccf5b75414d8ea262de9a13"
+"checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 "checksum subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "702662512f3ddeb74a64ce2fbbf3707ee1b6bb663d28bb054e0779bbc720d926"
@@ -1230,6 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tiny-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a1415431cb2398d84da64173f8473c792808314427d4a6f2f3ea85ae67239fe3"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,12 @@ bytes = "0.4"
 chrono = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
+hkdf = "0.7"
+hmac = "0.7"
 lazy_static = "1"
 prost-amino = "0.4.0"
 prost-amino-derive = "0.4.0"
+rand_os = "0.1"
 serde = "1"
 serde_derive = "1"
 serde_json = "1"
@@ -36,13 +39,15 @@ signatory = { version = "0.11.1", features = ["ed25519", "ecdsa"] }
 signatory-dalek = "0.11"
 signatory-secp256k1 = "0.11"
 signatory-ledger-tm = { version = "0.11", optional = true }
-subtle-encoding = "0.3"
+subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
 tendermint = { version = "0.2", path = "tendermint-rs" }
-yubihsm = { version = "0.21.0-alpha2", features = ["usb"], optional = true }
+tiny-bip39 = "0.6"
+yubihsm = { version = "0.21.0-alpha2", features = ["setup", "usb"], optional = true }
+zeroize = "0.5"
 
 [dev-dependencies]
 tempfile = "3"
-rand = "0.6"
+rand = "0.6" # TODO: switch to the getrandom crate
 
 [features]
 default = ["softsign"]

--- a/src/commands/yubihsm/mod.rs
+++ b/src/commands/yubihsm/mod.rs
@@ -5,9 +5,13 @@ use abscissa::Callable;
 mod detect;
 mod help;
 mod keys;
+mod setup;
 mod test;
 
-pub use self::{detect::DetectCommand, help::HelpCommand, keys::KeysCommand, test::TestCommand};
+pub use self::{
+    detect::DetectCommand, help::HelpCommand, keys::KeysCommand, setup::SetupCommand,
+    test::TestCommand,
+};
 
 /// The `yubihsm` subcommand
 #[derive(Debug, Options)]
@@ -20,6 +24,9 @@ pub enum YubihsmCommand {
 
     #[options(help = "key management subcommands")]
     Keys(KeysCommand),
+
+    #[options(help = "initial device setup and configuration")]
+    Setup(SetupCommand),
 
     #[options(help = "perform a signing test")]
     Test(TestCommand),
@@ -36,6 +43,7 @@ impl Callable for YubihsmCommand {
             YubihsmCommand::Detect(detect) => detect.call(),
             YubihsmCommand::Help(help) => help.call(),
             YubihsmCommand::Keys(keys) => keys.call(),
+            YubihsmCommand::Setup(setup) => setup.call(),
             YubihsmCommand::Test(test) => test.call(),
         }
     }
@@ -44,8 +52,9 @@ impl Callable for YubihsmCommand {
 impl YubihsmCommand {
     pub(super) fn config_path(&self) -> Option<&str> {
         match self {
-            YubihsmCommand::Detect(detect) => detect.config.as_ref().map(|s| s.as_ref()),
             YubihsmCommand::Keys(keys) => keys.config_path(),
+            YubihsmCommand::Setup(setup) => setup.config.as_ref().map(|s| s.as_ref()),
+            YubihsmCommand::Test(test) => test.config.as_ref().map(|s| s.as_ref()),
             _ => None,
         }
     }
@@ -53,6 +62,7 @@ impl YubihsmCommand {
     pub(super) fn verbose(&self) -> bool {
         match self {
             YubihsmCommand::Detect(detect) => detect.verbose,
+            YubihsmCommand::Setup(setup) => setup.verbose,
             YubihsmCommand::Test(test) => test.verbose,
             _ => false,
         }

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -1,0 +1,334 @@
+use abscissa::Callable;
+use bip39::{Language, Mnemonic};
+use chrono::Utc;
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use rand_os::{rand_core::RngCore, OsRng};
+use sha2::Sha512;
+use std::process;
+use subtle_encoding::bech32::Bech32;
+use yubihsm::{
+    authentication, object,
+    setup::{Profile, Role},
+    wrap, AuditOption, Capability, Connector, Credentials, Domain,
+};
+use zeroize::Zeroize;
+
+/// Domain separation string used as "info" for HKDF
+const HKDF_MNEMONIC_INFO: &[u8] = b"yubihsm setup BIP39 derivation";
+
+/// Domain separation for derivation hierarchy versions (ala BIP43's "purpose" field)
+const DERIVATION_VERSION: &[u8] = b"1";
+
+/// Key size to use for generating passwords and wrap keys (256-bits).
+/// This results in a 24-word BIP39 `Mnemonic` phrase.
+const KEY_SIZE: usize = 32;
+
+/// Role names
+const ADMIN_ROLE_NAME: &str = "admin";
+const OPERATOR_ROLE_NAME: &str = "operator";
+const AUDITOR_ROLE_NAME: &str = "auditor";
+const VALIDATOR_ROLE_NAME: &str = "validator";
+
+/// The `yubihsm setup` subcommand: performs initial device provisioning
+/// including creation of initial authentication and wrap keys.
+#[derive(Debug, Default, Options)]
+pub struct SetupCommand {
+    /// Path to configuration file
+    #[options(short = "c", long = "config")]
+    pub config: Option<String>,
+
+    /// Print debugging information
+    #[options(short = "v", long = "verbose")]
+    pub verbose: bool,
+}
+
+impl Callable for SetupCommand {
+    /// Perform initial YubiHSM dervice provisioning
+    fn call(&self) {
+        let hsm_connector = crate::yubihsm::connector();
+
+        let mnemonic = generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector.clone());
+        let roles = derive_roles_from_mnemonic(&mnemonic);
+        let wrap_key = derive_wrap_key_from_mnemonic(&mnemonic, 1);
+
+        // TODO(tarcieri): support for enabling forced auditing
+        let profile = Profile::default()
+            .audit_option(AuditOption::Off)
+            .roles(roles)
+            .wrap_keys(vec![wrap_key]);
+
+        let operator_password = RolePassword::derive_from_mnemonic(&mnemonic, OPERATOR_ROLE_NAME);
+        let auditor_password = RolePassword::derive_from_mnemonic(&mnemonic, AUDITOR_ROLE_NAME);
+        let validator_password = RolePassword::derive_from_mnemonic(&mnemonic, VALIDATOR_ROLE_NAME);
+
+        println!("This process will *ERASE* the configured YubiHSM2 and reinitialize it.");
+        println!("The following authentication keys will be created:");
+        println!();
+        println!("admin     (key 1): {}", &mnemonic);
+        println!("operator  (key 2): {}", operator_password.as_str());
+        println!("auditor   (key 3): {}", auditor_password.as_str());
+        println!("validator (key 4): {}", validator_password.as_str());
+
+        println!("\nAre you SURE you want erase your HSM and reinitialize it? (y/N)");
+        // TODO(tarcieri): prompt that they actually want to continue!!!
+
+        let report = yubihsm::setup::erase_device_and_init_with_profile(
+            hsm_connector.clone(),
+            crate::yubihsm::config().auth.credentials(),
+            profile,
+        )
+        .unwrap_or_else(|e| hsm_error(e.as_fail()));
+
+        println!("provisioning report: {:?}", report);
+    }
+}
+
+/// Generate entropy by combining entropy both from the host OS and from the
+/// YubiHSM2 itself (which includes an internal CSPRNG).
+///
+/// These are both used as input key material (IKM) for a key derivation
+/// function (HKDF) in order to derive the recovery passphrase, which ideally
+/// ensures that the passphrase will be securely random so long as at least
+/// one of the two inputs is secure.
+fn generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector: Connector) -> Mnemonic {
+    // We need to create our own client here since the global one maintains
+    // a persistent connection, and we need to close this one before we can
+    // reprovision the HSM
+    let mut hsm_client = yubihsm::Client::open(
+        hsm_connector,
+        crate::yubihsm::config().auth.credentials(),
+        false,
+    )
+    .unwrap_or_else(|e| hsm_error(&e));
+
+    // Obtain half of the IKM from the YubiHSM
+    let mut ikm = hsm_client
+        .get_pseudo_random(KEY_SIZE / 2)
+        .unwrap_or_else(|e| hsm_error(&e));
+
+    // Obtain another half of the IKM from the host OS
+    ikm.extend_from_slice(&[0u8; KEY_SIZE / 2]);
+    OsRng::new().unwrap().fill_bytes(&mut ikm[(KEY_SIZE / 2)..]);
+
+    let kdf = Hkdf::<Sha512>::extract(None, &ikm);
+
+    // 32-bytes (256-bits) -> 24 BIP32 words
+    let mut okm = [0u8; KEY_SIZE];
+    kdf.expand(HKDF_MNEMONIC_INFO, &mut okm).unwrap();
+    ikm.zeroize();
+
+    let result = Mnemonic::from_entropy(&okm, Language::English).unwrap();
+    okm.zeroize();
+
+    result
+}
+
+/// Derive the default roles form the given BIP39 `Mnemonic`
+fn derive_roles_from_mnemonic(mnemonic: &Mnemonic) -> Vec<Role> {
+    let admin_role = derive_admin_role_from_mnemonic(mnemonic);
+
+    // operator
+    let operator_role = derive_role_from_mnemonic(mnemonic, 2, OPERATOR_ROLE_NAME)
+        .capabilities(
+            Capability::GENERATE_ASYMMETRIC_KEY
+                | Capability::PUT_ASYMMETRIC_KEY
+                | Capability::GENERATE_HMAC_KEY
+                | Capability::PUT_HMAC_KEY
+                | Capability::IMPORT_WRAPPED
+                | Capability::EXPORT_WRAPPED
+                | Capability::GET_OPAQUE
+                | Capability::GET_OPTION
+                | Capability::GET_LOG_ENTRIES
+                | Capability::SIGN_ATTESTATION_CERTIFICATE,
+        )
+        .delegated_capabilities(Capability::all())
+        .domains(Domain::all());
+
+    // auditor
+    let auditor_role = derive_role_from_mnemonic(mnemonic, 3, AUDITOR_ROLE_NAME)
+        .capabilities(
+            Capability::GET_LOG_ENTRIES
+                | Capability::GET_OPTION
+                | Capability::PUT_OPTION
+                | Capability::GET_OPAQUE,
+        )
+        .delegated_capabilities(Capability::empty())
+        .domains(Domain::all());
+
+    // validator
+    let validator_role = derive_role_from_mnemonic(mnemonic, 4, VALIDATOR_ROLE_NAME)
+        .capabilities(
+            Capability::SIGN_ECDSA
+                | Capability::SIGN_EDDSA
+                | Capability::SIGN_ATTESTATION_CERTIFICATE
+                | Capability::GET_LOG_ENTRIES,
+        )
+        .delegated_capabilities(Capability::empty())
+        .domains(Domain::DOM1);
+
+    vec![admin_role, operator_role, auditor_role, validator_role]
+}
+
+/// Derive the admin role from the given mnemonic.
+///
+/// The admin role is somewhat different from the others and confers total
+/// authority over the HSM device.
+fn derive_admin_role_from_mnemonic(mnemonic: &Mnemonic) -> Role {
+    let admin_credentials = Credentials::new(
+        1,
+        authentication::Key::derive_from_password(mnemonic.as_ref().as_bytes()),
+    );
+
+    Role::new(admin_credentials)
+        .authentication_key_label(create_object_label(ADMIN_ROLE_NAME))
+        .capabilities(Capability::all())
+        .delegated_capabilities(Capability::all())
+        .domains(Domain::all())
+}
+
+/// Derive the initial settings for a role from the given mnemonic
+fn derive_role_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id, role_name: &str) -> Role {
+    let role_password = RolePassword::derive_from_mnemonic(&mnemonic, role_name);
+
+    let role_credentials = Credentials::new(
+        key_id,
+        authentication::Key::derive_from_password(role_password.as_bytes()),
+    );
+
+    Role::new(role_credentials).authentication_key_label(create_object_label(role_name))
+}
+
+/// Passwords for a given role, derived from a BIP39 `Mnemonic`.
+/// These are serialized as Bech32 for compactness.
+struct RolePassword(String);
+
+impl RolePassword {
+    /// Derive a role password from the given BIP39 `Mnemonic`
+    pub fn derive_from_mnemonic(mnemonic: &Mnemonic, role_name: &str) -> Self {
+        let mut secret_key =
+            derive_secret_from_mnemonic(mnemonic, &[b"role", role_name.as_bytes()]);
+
+        // YubiHSM authentication keys are 2 x AES-128 keys, derived using
+        // PBKDF2. This means we derive no value from more than 128-bits of
+        // entropy in the password, whereas shorter passwords are more
+        // convenient.
+        //
+        // For that reason, truncate the derived secret to 16-bytes
+        let truncated_secret_key = &secret_key[..(KEY_SIZE / 2)];
+
+        let result = RolePassword(
+            Bech32::default().encode(format!("kms-{}-password-", role_name), truncated_secret_key),
+        );
+        secret_key.zeroize();
+
+        result
+    }
+
+    /// Borrow the raw password as a `&str`
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+
+    /// Borrow the raw password as a byte slice
+    pub fn as_bytes(&self) -> &[u8] {
+        self.0.as_bytes()
+    }
+}
+
+impl Drop for RolePassword {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+/// Derive a wrap key from the given BIP39 `Mnemonic`
+fn derive_wrap_key_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id) -> wrap::Key {
+    // Capabilities given to the initial wrap key:
+    // wrap/unwrap both data and objects
+    let wrap_key_capabilities = Capability::EXPORT_WRAPPED
+        | Capability::IMPORT_WRAPPED
+        | Capability::WRAP_DATA
+        | Capability::UNWRAP_DATA;
+
+    // Allow the initial wrap key to create new objects with any other
+    // capabilities.
+    //
+    // To prevent escalation of privilege, no roles except administrators
+    // will be given the capability to export other objects.
+    let wrap_key_delegated_capabilities = Capability::all();
+
+    // Make the wrap key accessible from all domains. This allows it to
+    // import and export objects from any domain.
+    let wrap_key_domains = Domain::all();
+
+    // Label to put on the wrap key
+    let wrap_key_label = create_object_label("primary");
+
+    // Includes the key ID in the derivation path, which allows us to derive
+    // other wrap keys from the same seed `Mnemonic` phrase in the event one
+    // has been compromised.
+    wrap::Key::from_bytes(
+        key_id,
+        &derive_secret_from_mnemonic(mnemonic, &[b"wrap", format!("{}", key_id).as_bytes()]),
+    )
+    .unwrap()
+    .label(wrap_key_label)
+    .capabilities(wrap_key_capabilities)
+    .delegated_capabilities(wrap_key_delegated_capabilities)
+    .domains(wrap_key_domains)
+}
+
+/// Derive secrets from the given BIP39 `Mnemonic` ala a BIP32 (hardened)
+/// derivation hierarchy.
+fn derive_secret_from_mnemonic(mnemonic: &Mnemonic, path: &[&[u8]]) -> [u8; KEY_SIZE] {
+    // Domain separate the toplevel of the derivation hierarchy ala BIP43
+    let mut seed_hmac = Hmac::<Sha512>::new_varkey(mnemonic.entropy()).unwrap();
+    seed_hmac.input(DERIVATION_VERSION);
+
+    let mut seed = [0u8; KEY_SIZE];
+    seed.copy_from_slice(&seed_hmac.result().code()[KEY_SIZE..]);
+
+    // Simplified BIP32-like hierarchical derivation
+    path.iter()
+        .enumerate()
+        .fold(seed, |mut parent_key, (i, elem)| {
+            let mut hmac = Hmac::<Sha512>::new_varkey(&parent_key).unwrap();
+            hmac.input(elem);
+
+            let hmac_result = hmac.result().code();
+            parent_key.zeroize();
+
+            let (secret_key, chain_code) = hmac_result.split_at(KEY_SIZE);
+            let mut child_key = [0u8; KEY_SIZE];
+
+            if i < path.len() - 1 {
+                // Use chain code for all but the last element
+                child_key.copy_from_slice(chain_code);
+            } else {
+                // Use secret key for the last element
+                child_key.copy_from_slice(secret_key);
+            }
+
+            child_key
+        })
+}
+
+/// Create a label for a newly generated object which tags it with the date
+/// it was created
+fn create_object_label(label_prefix: &str) -> object::Label {
+    object::Label::from(
+        Utc::now()
+            .format(&format!("{}:%Y-%m-%d", label_prefix))
+            .to_string()
+            .as_ref(),
+    )
+}
+
+/// Handler for HSM errors
+fn hsm_error(e: &failure::Fail) -> ! {
+    status_err!("HSM error: {}", e);
+
+    // TODO: handle exits via abscissa
+    process::exit(1);
+}


### PR DESCRIPTION
Adds a `tmkms yubihsm setup` command which will erase / factory reset a YubiHSM2 and then set it up with the roles described in #174, using the provisioning process added to the `yubihsm` crate in https://github.com/tendermint/yubihsm-rs/pull/174

Relevant background for YubiHSM2 concepts can be found on Yubico's web site:

- [Capabilities](https://developers.yubico.com/YubiHSM2/Concepts/Capability.html) - HSM permissions (not actually OCap, sorry OCap fans). The access control model and best practices for these are described in the [Effective Capabilities](https://developers.yubico.com/YubiHSM2/Concepts/Effective_Capabilities.html) documentation.
- [Domains](https://developers.yubico.com/YubiHSM2/Concepts/Domain.html) - logical partitions with the HSM device. All accounts will have access to all domains except the validator account will initially be restricted to domain 1.
- [Objects](https://developers.yubico.com/YubiHSM2/Concepts/Object.html) - keys (and other opaque objects) stored in the HSM. Authentication keys are a type of object and the capabilities (and delegated capabilities) they possess control what an authenticated user/service is allowed to do.

## Roles

- **admin** (all domains)
  - access to all HSM capabilities, including the ability to generate/import new keywrap / KEKs, or rotate authentication keys
- **operator** (all domains)
  - generate new keys: asymmetric, HMAC (but not authentication keys or wrap keys, must be generated by admin)
  - import existing keys: asymmetric, HMAC, wrap
  - export/import existing asymmetric and HMAC keys under wrap
  - get opaque objects
  - get device information (e.g. storage used)
  - view the audit log (but not consume it)
  - attest asymmetric
- **auditor** (all domains)
  - view the audit log
  - mark the audit log as consumed
  - change auditing settings
  - get device information
  - get opaque objects
- **validator** (domain 1 only)
  - sign asymmetric (Ed25519/"EdDSA", ECDSA)
  - attest asymmetric
  - get device information

I would suggest avoiding too much customization of these roles to ensure future role-specific features added to the KMS can assume a standard profile.

## Key / Password Derivation

This PR derives entropy for a BIP39 mnemonic (24-words, 256-bits, ala Ledger Nano) using randomness from the host OS as well as the YubiHSM2. Both inputs are concatenated and used as HKDF input key material to derive a 256-bit master secret which is encoded as 24 BIP39 words.

This master secret is used directly (i.e. after Yubico's PBKDF2) as the administrator password for the device, conferring all authority.

It is also used as input to a simplified BIP32-like algorithm for deriving symmetric secrets, including the passwords for all non-admin roles. Presently these passwords are encoded using Bech32 with unique HRPs (both so they're shorter and easily distinguishable).

Additionally, it derives an initial wrap key. This is the key to be used for making encrypted backups of objects generated within the HSM. The wrap key's derivation path is personalized with the key's object ID, with the idea that several wrap keys can be derived from the same master secret in the event one of them is exposed.

All of this ensures the "24 words" are all that's needed to initialize several YubiHSM2s as identical copies of each other (sans importing backups of generated keys).

Here is an example of the output from the presently implemented (WIP) setup process:

```
This process will *ERASE* the configured YubiHSM2 and reinitialize it.
The following authentication keys will be created:

admin     (key 1): embrace kind nothing oak muscle design viable boil surge car arm project actress exact seminar march must upgrade shield chapter come van zebra transfer
operator  (key 2): kms-operator-password-1gv606hdgcvsazg89qjzzx56ysyc8wpa0
auditor   (key 3): kms-auditor-password-1a7w3peftjdgx8zn708na975w5q6pt2se
validator (key 4): kms-validator-password-1ptmh32fskx0ehq932d9w9lnp0yssz5lc

Are you SURE you want erase your HSM and reinitialize it? (y/N)
```

