### PR TITLE
Update to yubihsm v0.21.0-alpha2 crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,15 +98,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,13 +525,8 @@ name = "pbkdf2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -590,18 +576,6 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.49 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -745,11 +719,6 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "safemem"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "secp256k1"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -819,7 +788,7 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1022,7 +991,7 @@ dependencies = [
  "serde_derive 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory-dalek 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory-ledger-tm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1030,7 +999,7 @@ dependencies = [
  "subtle-encoding 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendermint 0.2.0",
- "yubihsm 0.21.0-alpha1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yubihsm 0.21.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1061,7 +1030,7 @@ name = "uuid"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.88 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1105,7 +1074,7 @@ dependencies = [
 
 [[package]]
 name = "yubihsm"
-version = "0.21.0-alpha1"
+version = "0.21.0-alpha2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1160,7 +1129,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5a90e2b463010cd0e0ce9a11d4a9d5d58d9f41d4a6ba3dcaf9e68b466e88b4"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e1e6fb1c9e3d6fcdec57216a74eaa03e41f52a22f13a16438251d8e88b89da"
 "checksum bit-vec 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4440d5cb623bb7390ae27fec0bb6c61111969860f8e3ae198bfa0663645e67cf"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
@@ -1221,7 +1189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6376b995db84c9791ab5d3f7bc3e315f8bc1a55fe139a0a2da24aa24e27de809"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
-"checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
@@ -1238,7 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
 "checksum rustc-demangle 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "adacaae16d02b6ec37fdc7acfcddf365978de76d1983d3ee22afc260e1ca9619"
 "checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
-"checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
@@ -1247,7 +1213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_json 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "27dce848e7467aa0e2fcaf0a413641499c0b745452aaca1194d24dedde9e13c9"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
-"checksum signal-hook 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1f272d1b7586bec132ed427f532dd418d8beca1ca7f2caf7df35569b1415a4b4"
+"checksum signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "97a47ae722318beceb0294e6f3d601205a1e6abaa4437d9d33e3a212233e3021"
 "checksum signatory 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ac100d1d4652d2a31be39a392aef8dd8b17284df088bcfcfd795be3bacbedfed"
 "checksum signatory-dalek 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5ed7678eaeb98cb23e1efdb5e961021b02d3bd9f8bab4d4e30c53ebb3dd50"
 "checksum signatory-ledger-tm 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2633f1e0a241347d31f2031b6053506dd72d9c5dedf06fe231526f049e4d1ed"
@@ -1275,6 +1241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum x25519-dalek 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "58e75de7a035f694df91838afa87faa8278bc484fa8d7dc34b5a24535cc2bb41"
-"checksum yubihsm 0.21.0-alpha1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d0816d5e1e0af74a1e828639e4838f2ba69cfa53abc61108c5d4ffccc488a73"
+"checksum yubihsm 0.21.0-alpha2 (registry+https://github.com/rust-lang/crates.io-index)" = "3994d9933448d8d269a16293beb31ff833f3eb27527f1c249889bf293c905c81"
 "checksum zeroize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7ddffec9ddef28ba2d6359bcbf0dc6772e62b112bc103dfb1e6fab46cd47c39"
 "checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ signatory-secp256k1 = "0.11"
 signatory-ledger-tm = { version = "0.11", optional = true }
 subtle-encoding = "0.3"
 tendermint = { version = "0.2", path = "tendermint-rs" }
-yubihsm = { version = "0.21.0-alpha1", features = ["usb"], optional = true }
+yubihsm = { version = "0.21.0-alpha2", features = ["usb"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/commands/yubihsm/detect.rs
+++ b/src/commands/yubihsm/detect.rs
@@ -34,7 +34,7 @@ impl Callable for DetectCommand {
         for device in devices.iter() {
             println!(
                 "- Serial #{} (bus {})",
-                device.serial_number.as_str(),
+                device.serial_number,
                 device.bus_number(),
             );
         }

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::yubihsm::get_hsm_client;
 use abscissa::Callable;
 use signatory::ed25519;
 use std::process;
@@ -43,7 +42,7 @@ impl Callable for GenerateCommand {
             }
         }
 
-        let mut hsm = get_hsm_client();
+        let mut hsm = crate::yubihsm::client();
 
         for key_id in &self.key_ids {
             let label =
@@ -54,7 +53,7 @@ impl Callable for GenerateCommand {
                 label,
                 DEFAULT_DOMAINS,
                 DEFAULT_CAPABILITIES,
-                yubihsm::AsymmetricAlg::Ed25519,
+                yubihsm::asymmetric::Algorithm::Ed25519,
             ) {
                 status_err!("couldn't generate key #{}: {}", key_id, e);
                 process::exit(1);

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,4 +1,3 @@
-use crate::yubihsm;
 use abscissa::Callable;
 use std::{
     thread,
@@ -27,7 +26,7 @@ pub struct TestCommand {
 impl Callable for TestCommand {
     /// Perform a signing test using the current HSM configuration
     fn call(&self) {
-        let mut hsm = yubihsm::get_hsm_client();
+        let mut hsm = crate::yubihsm::client();
 
         loop {
             let started_at = Instant::now();

--- a/src/config/provider/yubihsm.rs
+++ b/src/config/provider/yubihsm.rs
@@ -4,8 +4,8 @@ use abscissa::{
     secrets::{BorrowSecret, DebugSecret, Secret},
     util::Zeroize,
 };
-use std::process;
-use yubihsm::{Credentials, HttpConfig, SerialNumber, UsbConfig};
+use std::{process, str::FromStr};
+use yubihsm::{device::SerialNumber, Credentials, HttpConfig, UsbConfig};
 
 /// The (optional) `[providers.yubihsm]` config section
 #[derive(Clone, Deserialize, Debug)]
@@ -21,7 +21,7 @@ pub struct YubihsmConfig {
     pub keys: Vec<SigningKeyConfig>,
 
     /// Serial number of the YubiHSM to connect to
-    pub serial_number: Option<SerialNumber>,
+    pub serial_number: Option<String>,
 }
 
 impl YubihsmConfig {
@@ -45,7 +45,10 @@ impl YubihsmConfig {
                 process::exit(1);
             }
             AdapterConfig::Usb { timeout_ms } => UsbConfig {
-                serial: self.serial_number,
+                serial: self
+                    .serial_number
+                    .as_ref()
+                    .map(|serial| SerialNumber::from_str(serial).unwrap()),
                 timeout_ms,
             },
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,23 +145,3 @@ impl From<TmValidationError> for KmsError {
         err!(KmsErrorKind::InvalidMessageError, other).into()
     }
 }
-
-#[cfg(feature = "yubihsm")]
-impl From<yubihsm::connector::ConnectionError> for KmsError {
-    fn from(other: yubihsm::connector::ConnectionError) -> Self {
-        use yubihsm::connector::ConnectionErrorKind;
-
-        let kind = match other.kind() {
-            ConnectionErrorKind::AddrInvalid => KmsErrorKind::ConfigError,
-            ConnectionErrorKind::AccessDenied => KmsErrorKind::AccessError,
-            ConnectionErrorKind::IoError
-            | ConnectionErrorKind::ConnectionFailed
-            | ConnectionErrorKind::DeviceBusyError
-            | ConnectionErrorKind::RequestError
-            | ConnectionErrorKind::ResponseError
-            | ConnectionErrorKind::UsbError => KmsErrorKind::IoError,
-        };
-
-        Error::new(kind, Some(other.description().to_owned())).into()
-    }
-}

--- a/src/keyring/ed25519/yubihsm.rs
+++ b/src/keyring/ed25519/yubihsm.rs
@@ -6,8 +6,9 @@ use crate::{
     keyring::{ed25519::Signer, KeyRing},
 };
 use signatory::PublicKeyed;
+use yubihsm::signatory::Ed25519Signer;
 
-/// Label for ed25519-dalek provider
+/// Label for YubiHSM provider
 // TODO: use a non-string type for these, e.g. an enum
 pub const YUBIHSM_PROVIDER_LABEL: &str = "yubihsm";
 
@@ -25,17 +26,22 @@ pub fn init(keyring: &mut KeyRing, yubihsm_configs: &[YubihsmConfig]) -> Result<
         );
     }
 
-    let yubihsm_config = &yubihsm_configs[0];
-    let connector = yubihsm::UsbConnector::create(&yubihsm_config.usb_config())?;
-    let session =
-        yubihsm::signatory::Session::create(connector, yubihsm_config.auth.credentials())?;
+    let config = &yubihsm_configs[0];
 
-    for key_config in &yubihsm_config.keys {
-        let provider = Box::new(session.ed25519_signer(key_config.key)?);
+    let connector = crate::yubihsm::connector();
+    let credentials = config.auth.credentials();
+
+    for key_config in &config.keys {
+        let hsm = yubihsm::Client::create(connector.clone(), credentials.clone())?;
+        let signer = Ed25519Signer::create(hsm, key_config.key)?;
 
         keyring.add(
-            provider.public_key()?,
-            Signer::new(YUBIHSM_PROVIDER_LABEL, key_config.id.clone(), provider),
+            signer.public_key()?,
+            Signer::new(
+                YUBIHSM_PROVIDER_LABEL,
+                key_config.id.clone(),
+                Box::new(signer),
+            ),
         )?;
     }
 


### PR DESCRIPTION
The upstream changes in the `yubihsm` crate eliminate `Box<_>` from its public API, and replace it with a `struct yubihsm::Connector` type which abstracts across HTTP, USB, and the MockHSM. No generics, no traits, and thread safe.

It also eliminates the old Signatory `Session` type and allows the Signatory signers to use `yubihsm::Client` directly.

All of this should better handle the difficulties of managing different sessions across the same `yubihsm::Connector` lifetime (this was previously resulting in sporadic failures)

See https://github.com/tendermint/yubihsm-rs/pull/179 for more background