### PR TITLE
yubihsm: Support for exporting generated keys at creation time

### DIFF
--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -1,7 +1,13 @@
 use super::*;
 use abscissa::Callable;
 use signatory::ed25519;
-use std::process;
+use std::{
+    fs::OpenOptions,
+    io::Write,
+    os::unix::fs::OpenOptionsExt,
+    path::{Path, PathBuf},
+    process,
+};
 use tendermint::public_keys::ConsensusKey;
 
 /// The `yubihsm keys generate` subcommand
@@ -18,6 +24,18 @@ pub struct GenerateCommand {
     /// Type of key to generate (default 'ed25519')
     #[options(short = "t")]
     pub key_type: Option<String>,
+
+    /// Mark this key as non-exportable
+    #[options(no_short, long = "non-exportable")]
+    pub non_exportable: bool,
+
+    /// Create an encrypted backup of this key in the given file
+    #[options(short = "b", long = "backup")]
+    pub backup_file: Option<PathBuf>,
+
+    /// Key ID of the wrap key to use when creating a backup
+    #[options(no_short, long = "backup-key")]
+    pub backup_wrap_key: Option<yubihsm::object::Id>,
 
     /// Key IDs to generate
     #[options(free)]
@@ -43,6 +61,12 @@ impl Callable for GenerateCommand {
         }
 
         let mut hsm = crate::yubihsm::client();
+        let mut capabilities = DEFAULT_CAPABILITIES;
+
+        // If the key isn't explicitly marked as non-exportable, allow it to be exported
+        if !self.non_exportable {
+            capabilities |= yubihsm::Capability::EXPORTABLE_UNDER_WRAP;
+        }
 
         for key_id in &self.key_ids {
             let label =
@@ -51,8 +75,8 @@ impl Callable for GenerateCommand {
             if let Err(e) = hsm.generate_asymmetric_key(
                 *key_id,
                 label,
-                DEFAULT_DOMAINS,
-                DEFAULT_CAPABILITIES,
+                DEFAULT_DOMAINS, // TODO(tarcieri): customize domains
+                capabilities,
                 yubihsm::asymmetric::Algorithm::Ed25519,
             ) {
                 status_err!("couldn't generate key #{}: {}", key_id, e);
@@ -72,9 +96,73 @@ impl Callable for GenerateCommand {
                 key_id,
                 ConsensusKey::from(public_key)
             );
+
+            if let Some(ref backup_file) = self.backup_file {
+                assert_eq!(
+                    self.key_ids.len(),
+                    1,
+                    "can only create backups if generating one key at a time"
+                );
+                create_encrypted_backup(
+                    &mut hsm,
+                    *key_id,
+                    &backup_file,
+                    self.backup_wrap_key.unwrap_or(DEFAULT_WRAP_KEY),
+                );
+            }
         }
     }
 }
 
 // TODO: custom derive in abscissa
 impl_command!(GenerateCommand);
+
+/// Create an encrypted backup of this key under the given wrap key ID
+fn create_encrypted_backup(
+    hsm: &mut yubihsm::Client,
+    key_id: yubihsm::object::Id,
+    backup_file_path: &Path,
+    wrap_key_id: yubihsm::object::Id,
+) {
+    let wrapped_bytes = hsm
+        .export_wrapped(wrap_key_id, yubihsm::object::Type::AsymmetricKey, key_id)
+        .unwrap_or_else(|e| {
+            status_err!(
+                "couldn't export key {} under wrap key {}: {}",
+                key_id,
+                wrap_key_id,
+                e
+            );
+            process::exit(1);
+        });
+
+    let mut backup_file = OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(backup_file_path)
+        .unwrap_or_else(|e| {
+            status_err!(
+                "couldn't create backup file: {} ({})",
+                backup_file_path.display(),
+                e
+            );
+            process::exit(1);
+        });
+
+    backup_file
+        .write_all(&wrapped_bytes.into_vec())
+        .unwrap_or_else(|e| {
+            status_err!("error writing backup: {}", e);
+            process::exit(1);
+        });
+
+    status_ok!(
+        "Wrote",
+        "backup of key {} (encrypted under wrap key {}) to {}",
+        key_id,
+        wrap_key_id,
+        backup_file_path.display()
+    );
+}

--- a/src/commands/yubihsm/keys/mod.rs
+++ b/src/commands/yubihsm/keys/mod.rs
@@ -17,6 +17,9 @@ pub const DEFAULT_DOMAINS: yubihsm::Domain = yubihsm::Domain::DOM1;
 /// Default YubiHSM2 permissions for generated keys
 pub const DEFAULT_CAPABILITIES: yubihsm::Capability = yubihsm::Capability::SIGN_EDDSA;
 
+/// Default wrap key to use when exporting
+pub const DEFAULT_WRAP_KEY: yubihsm::object::Id = 1;
+
 /// The `yubihsm keys` subcommand
 #[derive(Debug, Options)]
 pub enum KeysCommand {


### PR DESCRIPTION
Adds the EXPORTABLE_UNDER_WRAP capability to generated Ed25519 keys (which can be disabled with the `--non-exportable` option) and a `-b` or `--backup` parameter to write an encrypted backup of a generated key.