### PR TITLE
yubihsm: Base64-encode YubiHSM backups

### DIFF
--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -8,6 +8,7 @@ use std::{
     path::{Path, PathBuf},
     process,
 };
+use subtle_encoding::base64;
 use tendermint::public_keys::ConsensusKey;
 
 /// The `yubihsm keys generate` subcommand
@@ -152,7 +153,7 @@ fn create_encrypted_backup(
         });
 
     backup_file
-        .write_all(&wrapped_bytes.into_vec())
+        .write_all(&base64::encode(&wrapped_bytes.into_vec()))
         .unwrap_or_else(|e| {
             status_err!("error writing backup: {}", e);
             process::exit(1);


### PR DESCRIPTION
This matches the behavior of yubihsm-shell, allowing backups generated with the KMS to be imported via that tool (and vice versa).