### PR TITLE
State tracking for double sign protection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
         command: |
           rustc --version
           cargo --version
-          cargo test --all --features "default softsign yubihsm yubihsm-mock"
+          cargo test --all --features "default softsign yubihsm yubihsm-mock" -- --test-threads 1
     - run:
         name: audit
         command: |

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 // Error types
 
+use crate::last_sign_state;
 use crate::prost;
 use abscissa::Error;
 use signatory;
@@ -77,6 +78,10 @@ pub enum KmsErrorKind {
     /// Verification operation failed
     #[fail(display = "verification failed")]
     VerificationError,
+
+    /// Signature invalid
+    #[fail(display = "attempted double sign")]
+    DoubleSign,
 }
 
 impl Display for KmsError {
@@ -143,5 +148,11 @@ impl From<tendermint::Error> for KmsError {
 impl From<TmValidationError> for KmsError {
     fn from(other: TmValidationError) -> Self {
         err!(KmsErrorKind::InvalidMessageError, other).into()
+    }
+}
+
+impl From<last_sign_state::LastSignError> for KmsError {
+    fn from(other: last_sign_state::LastSignError) -> Self {
+        err!(KmsErrorKind::DoubleSign, other).into()
     }
 }

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -1,26 +1,21 @@
-use std::{
-    path::Path,
-    fs::File,
-    io::prelude::*,
-};
-use tendermint::chain;
-use serde_json;
 use abscissa::Error;
+use serde_json;
+use std::{fs::File, io::prelude::*, path::Path};
+use tendermint::chain;
 
-
-#[derive(Serialize,Deserialize)]
-struct LastSignData{
+#[derive(Serialize, Deserialize)]
+struct LastSignData {
     pub height: i64,
     pub round: i64,
-    pub step : i8,
+    pub step: i8,
     pub signature: String,
-    pub signbytes: String,      
+    pub signbytes: String,
 }
 
-pub struct LastSignState{
+pub struct LastSignState {
     data: LastSignData,
     file: File,
-    chain_id: chain::Id
+    chain_id: chain::Id,
 }
 
 /// Error type
@@ -28,7 +23,7 @@ pub struct LastSignState{
 pub struct LastSignError(Error<LastSignErrorKind>);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
-pub enum LastSignErrorKind{
+pub enum LastSignErrorKind {
     #[fail(display = "height regression")]
     HeightRegression,
     #[fail(display = "step regression")]
@@ -43,48 +38,70 @@ impl From<Error<LastSignErrorKind>> for LastSignError {
     }
 }
 
-impl LastSignState{
-    pub fn init_state(&mut self, path: &Path) -> std::io::Result<()>{
-        if path.exists(){
+impl LastSignState {
+    pub fn init_state(&mut self, path: &Path) -> std::io::Result<()> {
+        if path.exists() {
             return Ok(());
         }
         self.file = File::create(self.filename())?;
-        self.file.write_all(serde_json::to_string(&self.data).unwrap().as_ref())?;
+        self.file
+            .write_all(serde_json::to_string(&self.data).unwrap().as_ref())?;
         self.file.sync_all()?;
         return Ok(());
     }
 
-   pub fn load_state(&mut self, path:&Path) -> std::io::Result<()>{
+    pub fn load_state(&mut self, path: &Path) -> std::io::Result<()> {
         self.file = File::open(path)?;
         let mut contents = String::new();
         self.file.read_to_string(&mut contents)?;
-        self.data = serde_json::from_str(&contents).unwrap();       
-        return Ok(());    
+        self.data = serde_json::from_str(&contents).unwrap();
+        return Ok(());
     }
-    
-   pub fn filename(&self) -> String{
+
+    pub fn filename(&self) -> String {
         self.chain_id.as_str().to_owned() + "_validator_state.json"
     }
 
-   pub fn check_and_update_hrs(&mut self, height: i64, round:i64, step:i8)->Result<(),LastSignError>{
-       if height < self.data.height{
-            fail!(HeightRegression, "last height:{} new height:{}", self.data.height, height);
-       } 
-       if height == self.data.height {
-            if  round < self.data.round{
-                fail!(RoundRegression, "round regression at height:{} last round:{} new round:{}",height, self.data.round, round)
+    pub fn check_and_update_hrs(
+        &mut self,
+        height: i64,
+        round: i64,
+        step: i8,
+    ) -> Result<(), LastSignError> {
+        if height < self.data.height {
+            fail!(
+                HeightRegression,
+                "last height:{} new height:{}",
+                self.data.height,
+                height
+            );
+        }
+        if height == self.data.height {
+            if round < self.data.round {
+                fail!(
+                    RoundRegression,
+                    "round regression at height:{} last round:{} new round:{}",
+                    height,
+                    self.data.round,
+                    round
+                )
             }
-            if round == self.data.round{
-                if step < self.data.step{
-                        fail!(StepRegression, "round regression at height:{} round:{} last step:{} new step:{}",height,round, self.data.step, step)
+            if round == self.data.round {
+                if step < self.data.step {
+                    fail!(
+                        StepRegression,
+                        "round regression at height:{} round:{} last step:{} new step:{}",
+                        height,
+                        round,
+                        self.data.step,
+                        step
+                    )
                 }
             }
-       }
+        }
         self.data.height = height;
         self.data.round = round;
         self.data.step = step;
         Ok(())
-   }
-
-
+    }
 }

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -76,7 +76,7 @@ impl LastSignState {
 
         let mut contents = String::new();
         lst.file.read_to_string(&mut contents)?;
-        lst.data = serde_json::from_str(&contents).unwrap();
+        lst.data = serde_json::from_str(&contents)?;
         Ok(lst)
     }
 

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -1,0 +1,90 @@
+use std::{
+    path::Path,
+    fs::File,
+    io::prelude::*,
+};
+use tendermint::chain;
+use serde_json;
+use abscissa::Error;
+
+
+#[derive(Serialize,Deserialize)]
+struct LastSignData{
+    pub height: i64,
+    pub round: i64,
+    pub step : i8,
+    pub signature: String,
+    pub signbytes: String,      
+}
+
+pub struct LastSignState{
+    data: LastSignData,
+    file: File,
+    chain_id: chain::Id
+}
+
+/// Error type
+#[derive(Debug)]
+pub struct LastSignError(Error<LastSignErrorKind>);
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+pub enum LastSignErrorKind{
+    #[fail(display = "height regression")]
+    HeightRegression,
+    #[fail(display = "step regression")]
+    StepRegression,
+    #[fail(display = "round regression")]
+    RoundRegression,
+}
+
+impl From<Error<LastSignErrorKind>> for LastSignError {
+    fn from(other: Error<LastSignErrorKind>) -> Self {
+        LastSignError(other)
+    }
+}
+
+impl LastSignState{
+    pub fn init_state(&mut self, path: &Path) -> std::io::Result<()>{
+        if path.exists(){
+            return Ok(());
+        }
+        self.file = File::create(self.filename())?;
+        self.file.write_all(serde_json::to_string(&self.data).unwrap().as_ref())?;
+        self.file.sync_all()?;
+        return Ok(());
+    }
+
+   pub fn load_state(&mut self, path:&Path) -> std::io::Result<()>{
+        self.file = File::open(path)?;
+        let mut contents = String::new();
+        self.file.read_to_string(&mut contents)?;
+        self.data = serde_json::from_str(&contents).unwrap();       
+        return Ok(());    
+    }
+    
+   pub fn filename(&self) -> String{
+        self.chain_id.as_str().to_owned() + "_validator_state.json"
+    }
+
+   pub fn check_and_update_hrs(&mut self, height: i64, round:i64, step:i8)->Result<(),LastSignError>{
+       if height < self.data.height{
+            fail!(HeightRegression, "last height:{} new height:{}", self.data.height, height);
+       } 
+       if height == self.data.height {
+            if  round < self.data.round{
+                fail!(RoundRegression, "round regression at height:{} last round:{} new round:{}",height, self.data.round, round)
+            }
+            if round == self.data.round{
+                if step < self.data.step{
+                        fail!(StepRegression, "round regression at height:{} round:{} last step:{} new step:{}",height,round, self.data.step, step)
+                }
+            }
+       }
+        self.data.height = height;
+        self.data.round = round;
+        self.data.step = step;
+        Ok(())
+   }
+
+
+}

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -1,15 +1,15 @@
+
 use abscissa::Error;
 use serde_json;
 use std::{fs::File, io::prelude::*, path::Path};
-use tendermint::chain;
+use tendermint::{chain, block};
 
 #[derive(Serialize, Deserialize)]
 struct LastSignData {
     pub height: i64,
     pub round: i64,
     pub step: i8,
-    pub signature: String,
-    pub signbytes: String,
+    pub block_id:  Option<block::Id>,
 }
 
 pub struct LastSignState {
@@ -30,6 +30,8 @@ pub enum LastSignErrorKind {
     StepRegression,
     #[fail(display = "round regression")]
     RoundRegression,
+    #[fail(display = "invalid block id")]
+    DoubleSign,
 }
 
 impl From<Error<LastSignErrorKind>> for LastSignError {
@@ -49,7 +51,6 @@ impl LastSignState {
         self.file.sync_all()?;
         return Ok(());
     }
-
     pub fn load_state(&mut self, path: &Path) -> std::io::Result<()> {
         self.file = File::open(path)?;
         let mut contents = String::new();
@@ -57,20 +58,20 @@ impl LastSignState {
         self.data = serde_json::from_str(&contents).unwrap();
         return Ok(());
     }
-
     pub fn filename(&self) -> String {
         self.chain_id.as_str().to_owned() + "_validator_state.json"
     }
-
+    
     pub fn check_and_update_hrs(
         &mut self,
         height: i64,
         round: i64,
         step: i8,
+        block_id:Option<block::Id>, 
     ) -> Result<(), LastSignError> {
         if height < self.data.height {
             fail!(
-                HeightRegression,
+                LastSignErrorKind::HeightRegression,
                 "last height:{} new height:{}",
                 self.data.height,
                 height
@@ -79,7 +80,7 @@ impl LastSignState {
         if height == self.data.height {
             if round < self.data.round {
                 fail!(
-                    RoundRegression,
+                    LastSignErrorKind::RoundRegression,
                     "round regression at height:{} last round:{} new round:{}",
                     height,
                     self.data.round,
@@ -87,9 +88,10 @@ impl LastSignState {
                 )
             }
             if round == self.data.round {
+  
                 if step < self.data.step {
                     fail!(
-                        StepRegression,
+                        LastSignErrorKind::StepRegression,
                         "round regression at height:{} round:{} last step:{} new step:{}",
                         height,
                         round,
@@ -97,11 +99,70 @@ impl LastSignState {
                         step
                     )
                 }
+
+                if block_id != None && self.data.block_id != None && self.data.block_id != block_id {
+                    fail!(
+                    LastSignErrorKind::DoubleSign,
+                    "Attempting to sign a second proposal at height:{} round:{} step:{} old block id:{} new block {}",
+                    height,
+                    round,
+                    step,
+                    self.data.block_id.clone().unwrap(),
+                    block_id.unwrap()
+                    )
+                }
             }
         }
         self.data.height = height;
         self.data.round = round;
         self.data.step = step;
+        self.data.block_id = block_id;
         Ok(())
     }
+}
+#[cfg(test)]
+mod tests {
+    use tendermint::{chain, block};
+    use std::str::FromStr;
+    use super::*;
+
+    const EXAMPLE_BLOCK_ID:&str ="26C0A41F3243C6BCD7AD2DFF8A8D83A71D29D307B5326C227F734A1A512FE47D";
+
+    const EXAMPLE_DOUBLE_SIGN_BLOCK_ID:&str = "2470A41F3243C6BCD7AD2DFF8A8D83A71D29D307B5326C227F734A1A512FE47D";
+
+
+#[test]
+fn hrs_test(){
+    let mut last_sign_state = LastSignState{
+        data:LastSignData{
+            height: 1,
+            round: 1,
+            step: 0,
+            block_id:None,
+        },
+        file: File::create("/tmp/tmp_state.json").unwrap(),
+        chain_id:"example-chain".parse::<chain::Id>().unwrap()
+    };
+    assert_eq!(last_sign_state.check_and_update_hrs(2,0,0,None).unwrap(),())
+}
+
+#[test]
+fn hrs_test_double_sign(){
+    let mut last_sign_state = LastSignState{
+        data:LastSignData{
+            height: 1,
+            round: 1,
+            step: 0,
+            block_id:Some(block::Id::from_str(EXAMPLE_BLOCK_ID).unwrap()),
+        },
+        file: File::create("/tmp/tmp_state.json").unwrap(),
+        chain_id:"example-chain".parse::<chain::Id>().unwrap()
+    };
+    let double_sign_block= block::Id::from_str(EXAMPLE_DOUBLE_SIGN_BLOCK_ID).unwrap();
+    let err = last_sign_state.check_and_update_hrs(1,1,1,Some(double_sign_block));
+
+    let double_sign_error = LastSignErrorKind::DoubleSign;
+
+    assert_eq!(err.expect_err("Expect Double Sign error").0.kind(),&double_sign_error)
+}
 }

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -77,14 +77,14 @@ impl LastSignState {
         let mut contents = String::new();
         lst.file.read_to_string(&mut contents)?;
         lst.data = serde_json::from_str(&contents).unwrap();
-        return Ok(lst);
+        Ok(lst)
     }
 
     pub fn sync_to_disk(&mut self) -> std::io::Result<()> {
         self.file
             .write_all(serde_json::to_string(&self.data).unwrap().as_ref())?;
         self.file.sync_all()?;
-        return Ok(());
+        Ok(())
     }
 
     pub fn check_and_update_hrs(

--- a/src/last_sign_state.rs
+++ b/src/last_sign_state.rs
@@ -2,7 +2,7 @@ use abscissa::Error;
 use serde_json;
 use std::{
     fmt::{self, Display},
-    fs::File,
+    fs::{File, OpenOptions},
     io::prelude::*,
     path::Path,
 };
@@ -70,7 +70,7 @@ impl LastSignState {
         }
         let mut lst = LastSignState {
             data: EMPTY_DATA,
-            file: File::open(path)?,
+            file: OpenOptions::new().read(true).write(true).open(path)?,
             _chain_id: chain_id,
         };
 
@@ -82,7 +82,7 @@ impl LastSignState {
 
     pub fn sync_to_disk(&mut self) -> std::io::Result<()> {
         self.file
-            .write_all(serde_json::to_string(&self.data).unwrap().as_ref())?;
+            .write_all(serde_json::to_string(&self.data)?.as_ref())?;
         self.file.sync_all()?;
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ mod keyring;
 mod rpc;
 mod session;
 mod unix_connection;
+mod last_sign_state;
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,10 +30,10 @@ mod client;
 mod commands;
 mod config;
 mod keyring;
+mod last_sign_state;
 mod rpc;
 mod session;
 mod unix_connection;
-mod last_sign_state;
 #[cfg(feature = "yubihsm")]
 mod yubihsm;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -55,7 +55,7 @@ impl Session<SecretConnection<TcpStream>> {
         let public_key = SecretConnectionKey::from(ed25519::public_key(&signer)?);
         let connection = SecretConnection::new(socket, &public_key, &signer)?;
         let last_sign_state = LastSignState::load_state(
-            Path::new(&(chain_id.as_ref().to_owned() + "_priv_validator_state.json")),
+            Path::new(&(chain_id.to_string() + "_priv_validator_state.json")),
             chain_id,
         )?;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -134,8 +134,8 @@ where
     fn sign<T: TendermintRequest + Debug>(&mut self, mut request: T) -> Result<Response, KmsError> {
         request.validate()?;
 
-        match request.consensus_state() {
-            Some(cs) => match self.last_sign_state.check_and_update_hrs(
+        if let Some(cs) = request.consensus_state() {
+            match self.last_sign_state.check_and_update_hrs(
                 cs.height,
                 cs.round,
                 cs.step,
@@ -146,8 +146,7 @@ where
                     debug! {"Double sign event: {}",e}
                     return Err(KmsError::from(e));
                 }
-            },
-            None => (),
+            }
         }
         self.last_sign_state.sync_to_disk()?;
         let mut to_sign = vec![];

--- a/src/session.rs
+++ b/src/session.rs
@@ -54,7 +54,10 @@ impl Session<SecretConnection<TcpStream>> {
         let signer = Ed25519Signer::from(secret_connection_key);
         let public_key = SecretConnectionKey::from(ed25519::public_key(&signer)?);
         let connection = SecretConnection::new(socket, &public_key, &signer)?;
-        let last_sign_state = LastSignState::load_state(Path::new(chain_id.as_ref()), chain_id)?;
+        let last_sign_state = LastSignState::load_state(
+            Path::new(&(chain_id.as_ref().to_owned() + "_priv_validator_state.json")),
+            chain_id,
+        )?;
 
         Ok(Self {
             chain_id,
@@ -74,7 +77,10 @@ impl Session<UnixConnection<UnixStream>> {
 
         let socket = UnixStream::connect(socket_path)?;
         let connection = UnixConnection::new(socket);
-        let last_sign_state = LastSignState::load_state(Path::new(chain_id.as_ref()), chain_id)?;
+        let last_sign_state = LastSignState::load_state(
+            Path::new(&(chain_id.as_ref().to_owned() + "_priv_validator_state.json")),
+            chain_id,
+        )?;
 
         Ok(Self {
             chain_id,
@@ -143,6 +149,7 @@ where
             },
             None => (),
         }
+        self.last_sign_state.sync_to_disk()?;
         let mut to_sign = vec![];
         request.sign_bytes(self.chain_id, &mut to_sign)?;
 

--- a/tendermint-rs/src/amino_types/mod.rs
+++ b/tendermint-rs/src/amino_types/mod.rs
@@ -21,7 +21,7 @@ pub use self::{
     proposal::{SignProposalRequest, SignedProposalResponse, AMINO_NAME as PROPOSAL_AMINO_NAME},
     remote_error::RemoteError,
     secret_connection::AuthSigMessage,
-    signature::{SignableMsg, SignedMsgType},
+    signature::{ConsensusState, SignableMsg, SignedMsgType},
     time::TimeMsg,
     validate::ConsensusMessage,
     vote::{SignVoteRequest, SignedVoteResponse, AMINO_NAME as VOTE_AMINO_NAME},

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -135,7 +135,7 @@ impl SignableMsg for SignProposalRequest {
             Some(ref p) => Some(ConsensusState {
                 height: p.height,
                 round: p.round,
-                step: 3, 
+                step: 3,
                 block_id: {
                     match p.block_id {
                         Some(ref b) => match b.parse_block_id() {

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -135,7 +135,7 @@ impl SignableMsg for SignProposalRequest {
             Some(ref p) => Some(ConsensusState {
                 height: p.height,
                 round: p.round,
-                step: 1, //TODO check if correct steo
+                step: 3, 
                 block_id: {
                     match p.block_id {
                         Some(ref b) => match b.parse_block_id() {

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -1,10 +1,11 @@
 use super::{
     block_id::{BlockId, CanonicalBlockId, CanonicalPartSetHeader},
     remote_error::RemoteError,
-    signature::{SignableMsg, SignedMsgType},
+    signature::{ConsensusState, SignableMsg, SignedMsgType},
     time::TimeMsg,
     validate::{ConsensusMessage, ValidationError, ValidationErrorKind::*},
 };
+use crate::block::ParseId;
 use crate::{block, chain, error::Error};
 use bytes::BufMut;
 use prost::{EncodeError, Message};
@@ -127,6 +128,25 @@ impl SignableMsg for SignProposalRequest {
         match self.proposal {
             Some(ref p) => p.validate_basic(),
             None => Err(MissingConsensusMessage.into()),
+        }
+    }
+    fn consensus_state(&self) -> Option<ConsensusState> {
+        match self.proposal {
+            Some(ref p) => Some(ConsensusState {
+                height: p.height,
+                round: p.round,
+                step: 1, //TODO check if correct steo
+                block_id: {
+                    match p.block_id {
+                        Some(ref b) => match b.parse_block_id() {
+                            Ok(id) => Some(id),
+                            Err(_) => None,
+                        },
+                        None => None,
+                    }
+                },
+            }),
+            None => None,
         }
     }
 }

--- a/tendermint-rs/src/amino_types/signature.rs
+++ b/tendermint-rs/src/amino_types/signature.rs
@@ -1,5 +1,5 @@
 use super::validate::ValidationError;
-use crate::chain;
+use crate::{block, chain};
 use bytes::BufMut;
 use prost::{DecodeError, EncodeError};
 use signatory::ed25519;
@@ -15,8 +15,15 @@ pub trait SignableMsg {
 
     /// Set the Ed25519 signature on the underlying message
     fn set_signature(&mut self, sig: &ed25519::Signature);
-
     fn validate(&self) -> Result<(), ValidationError>;
+    fn consensus_state(&self) -> Option<ConsensusState>;
+}
+
+pub struct ConsensusState {
+    pub height: i64,
+    pub round: i64,
+    pub step: i8,
+    pub block_id: Option<block::Id>,
 }
 
 /// Signed message types. This follows:

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -156,7 +156,7 @@ impl SignableMsg for SignVoteRequest {
             Some(ref v) => Some(ConsensusState {
                 height: v.height,
                 round: v.round,
-                step: 5, //To Do check if correct.
+                step: 6, 
                 block_id: {
                     match v.block_id {
                         Some(ref b) => match b.parse_block_id() {

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -156,7 +156,7 @@ impl SignableMsg for SignVoteRequest {
             Some(ref v) => Some(ConsensusState {
                 height: v.height,
                 round: v.round,
-                step: 6, 
+                step: 6,
                 block_id: {
                     match v.block_id {
                         Some(ref b) => match b.parse_block_id() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -291,7 +291,7 @@ fn test_handle_and_sign_proposal() {
         let proposal = amino_types::proposal::Proposal {
             msg_type: amino_types::SignedMsgType::Proposal.to_u32(),
             height: 12345,
-            round: 23456,
+            round: 1,
             timestamp: Some(t),
             pol_round: -1,
             block_id: None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -205,10 +205,8 @@ impl ProtocolTester {
     where
         F: FnOnce(ProtocolTester),
     {
-
         //delete a state file if present
         fs::remove_file("test_chain_id_priv_validator_state.json").unwrap();
-
 
         let tcp_device = KmsProcess::create_tcp();
         let tcp_connection = tcp_device.create_connection();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -205,7 +205,6 @@ impl ProtocolTester {
     where
         F: FnOnce(ProtocolTester),
     {
-
         let tcp_device = KmsProcess::create_tcp();
         let tcp_connection = tcp_device.create_connection();
         let unix_device = KmsProcess::create_unix();
@@ -225,7 +224,6 @@ impl Drop for ProtocolTester {
         self.tcp_device.process.kill().unwrap();
         self.unix_device.process.kill().unwrap();
         fs::remove_file("test_chain_id_priv_validator_state.json").unwrap();
-
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -205,8 +205,6 @@ impl ProtocolTester {
     where
         F: FnOnce(ProtocolTester),
     {
-        //delete a state file if present
-        fs::remove_file("test_chain_id_priv_validator_state.json").unwrap();
 
         let tcp_device = KmsProcess::create_tcp();
         let tcp_connection = tcp_device.create_connection();
@@ -226,6 +224,8 @@ impl Drop for ProtocolTester {
     fn drop(&mut self) {
         self.tcp_device.process.kill().unwrap();
         self.unix_device.process.kill().unwrap();
+        fs::remove_file("test_chain_id_priv_validator_state.json").unwrap();
+
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,7 @@ use rand::Rng;
 use signatory::{ed25519, encoding::Identity, Decode, Signature};
 use signatory_dalek::{Ed25519Signer, Ed25519Verifier};
 use std::{
+    fs,
     io::{self, Cursor, Read, Write},
     net::{TcpListener, TcpStream},
     os::unix::net::{UnixListener, UnixStream},
@@ -204,6 +205,11 @@ impl ProtocolTester {
     where
         F: FnOnce(ProtocolTester),
     {
+
+        //delete a state file if present
+        fs::remove_file("test_chain_id_priv_validator_state.json").unwrap();
+
+
         let tcp_device = KmsProcess::create_tcp();
         let tcp_connection = tcp_device.create_connection();
         let unix_device = KmsProcess::create_unix();


### PR DESCRIPTION
Starting to work on tracking state in the file system for each client to prevent double signing. 

This is basically duplicating the approach taken inside of tendermint where were we track forward round progression as a measure of preventing a double sign.