### PR TITLE
config: Allow setting config path via TMKMS_CONFIG_FILE

### DIFF
--- a/src/commands/yubihsm/keys/mod.rs
+++ b/src/commands/yubihsm/keys/mod.rs
@@ -43,12 +43,12 @@ pub enum KeysCommand {
 
 impl KeysCommand {
     /// Optional path to the configuration file
-    pub(super) fn config_path(&self) -> Option<&str> {
+    pub(super) fn config_path(&self) -> Option<&String> {
         match self {
-            KeysCommand::Export(export) => export.config.as_ref().map(|s| s.as_ref()),
-            KeysCommand::Generate(generate) => generate.config.as_ref().map(|s| s.as_ref()),
-            KeysCommand::List(list) => list.config.as_ref().map(|s| s.as_ref()),
-            KeysCommand::Import(import) => import.config.as_ref().map(|s| s.as_ref()),
+            KeysCommand::Export(export) => export.config.as_ref(),
+            KeysCommand::Generate(generate) => generate.config.as_ref(),
+            KeysCommand::List(list) => list.config.as_ref(),
+            KeysCommand::Import(import) => import.config.as_ref(),
             _ => None,
         }
     }

--- a/src/commands/yubihsm/mod.rs
+++ b/src/commands/yubihsm/mod.rs
@@ -50,11 +50,11 @@ impl Callable for YubihsmCommand {
 }
 
 impl YubihsmCommand {
-    pub(super) fn config_path(&self) -> Option<&str> {
+    pub(super) fn config_path(&self) -> Option<&String> {
         match self {
             YubihsmCommand::Keys(keys) => keys.config_path(),
-            YubihsmCommand::Setup(setup) => setup.config.as_ref().map(|s| s.as_ref()),
-            YubihsmCommand::Test(test) => test.config.as_ref().map(|s| s.as_ref()),
+            YubihsmCommand::Setup(setup) => setup.config.as_ref(),
+            YubihsmCommand::Test(test) => test.config.as_ref(),
             _ => None,
         }
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,9 @@ pub mod validator;
 pub use self::validator::*;
 use self::{chain::ChainConfig, provider::ProviderConfig};
 
+/// Environment variable containing path to config file
+pub const CONFIG_ENV_VAR: &str = "TMKMS_CONFIG_FILE";
+
 /// Name of the KMS configuration file
 pub const CONFIG_FILE_NAME: &str = "tmkms.toml";
 


### PR DESCRIPTION
This is nice for using tmkms interactively via the command line (e.g. `tmkms yubihsm`) in cases where `tmkms.toml` is not in the current working directory.