### PR TITLE
tendermint-rs v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1115,7 +1115,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.5.0-alpha1"
+version = "0.5.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1204,7 +1204,7 @@ dependencies = [
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.5.0-alpha1",
+ "tendermint 0.5.0",
  "tiny-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,4 +1,8 @@
-## 0.5.0 (TBD)
+## [0.5.0] (2019-03-13)
+
+- Rename `SecretConnectionKey` to `secret_connection::PublicKey`, add
+  `secret_connection::PeerId` ([#219])
+- Move `ConsensusState` under `chain::state` ([#205])
 
 ## 0.4.0 (N/A)
 
@@ -49,4 +53,7 @@ This release is compatible with tendermint [v0.28]
 
 - Initial release
 
+[0.5.0]: https://github.com/tendermint/kms/pull/220
+[#219]: https://github.com/tendermint/kms/pull/219
+[#205]: https://github.com/tendermint/kms/pull/219
 [#181]: https://github.com/tendermint/kms/pull/181

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.5.0-alpha1" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.5.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -16,7 +16,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.5.0-alpha1"
+    html_root_url = "https://docs.rs/tendermint/0.5.0"
 )]
 
 #[macro_use]


### PR DESCRIPTION
Cutting a final release of this prior to a tmkms v0.5.0-alpha2:

- Rename `SecretConnectionKey` to `secret_connection::PublicKey`, add `secret_connection::PeerId` (#219)
- Move `ConsensusState` under `chain::state` (#205)