### PR TITLE
tmkms v0.5.0-alpha2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.5.0-alpha1"
+version = "0.5.0-alpha2"
 dependencies = [
  "abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.5.0-alpha1"
+version     = "0.5.0-alpha2"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"


### PR DESCRIPTION
This should be the feature-complete v0.5.0 release. This is a final test release before cutting the final version.