### PR TITLE
Implement chain-specific keyrings (closes #231, #111)

### DIFF
--- a/src/chain/guard.rs
+++ b/src/chain/guard.rs
@@ -1,19 +1,19 @@
-use super::{Chain, Id};
-use std::{collections::BTreeMap, sync::RwLockReadGuard};
+use super::{Chain, Id, Registry};
+use std::sync::RwLockReadGuard;
 
-/// Wrapper for a `RwLockReadGuard<'static, BTreeMap<Id, Chain>>`, allowing access to
+/// Wrapper for a `RwLockReadGuard<'static, Registry>`, allowing access to
 /// global information about particular Tendermint networks / "chains"
-pub struct Guard<'lock>(RwLockReadGuard<'lock, BTreeMap<Id, Chain>>);
+pub struct Guard<'lock>(RwLockReadGuard<'lock, Registry>);
 
-impl<'lock> From<RwLockReadGuard<'lock, BTreeMap<Id, Chain>>> for Guard<'lock> {
-    fn from(guard: RwLockReadGuard<'lock, BTreeMap<Id, Chain>>) -> Guard<'lock> {
+impl<'lock> From<RwLockReadGuard<'lock, Registry>> for Guard<'lock> {
+    fn from(guard: RwLockReadGuard<'lock, Registry>) -> Guard<'lock> {
         Guard(guard)
     }
 }
 
 impl<'lock> Guard<'lock> {
     /// Get information about a particular chain ID (if registered)
-    pub fn chain(&self, chain_id: Id) -> Option<&Chain> {
-        self.0.get(&chain_id)
+    pub fn get_chain(&self, chain_id: &Id) -> Option<&Chain> {
+        self.0.get_chain(chain_id)
     }
 }

--- a/src/chain/registry.rs
+++ b/src/chain/registry.rs
@@ -2,35 +2,69 @@
 
 use super::{Chain, Guard, Id};
 use crate::{
-    config::chain::ChainConfig,
-    error::{KmsError, KmsErrorKind::ConfigError},
+    error::{KmsError, KmsErrorKind::*},
+    keyring,
 };
 use std::{collections::BTreeMap, sync::RwLock};
 
 lazy_static! {
-    pub static ref REGISTRY: Registry = Registry::default();
-}
-
-/// Initialize the chain registry from the configuration file
-pub fn load_from_config(chain_configs: &[ChainConfig]) -> Result<(), KmsError> {
-    for config in chain_configs {
-        REGISTRY.register(Chain::from_config(config)?)?;
-    }
-
-    Ok(())
+    pub static ref REGISTRY: GlobalRegistry = GlobalRegistry::default();
 }
 
 /// Registry of blockchain networks known to the KMS
-// The `RwLock` is a bit of futureproofing as this data structure is for the
+#[derive(Default)]
+pub struct Registry(BTreeMap<Id, Chain>);
+
+impl Registry {
+    /// Add a key to a keyring for a chain stored in the registry
+    pub fn add_to_keyring(
+        &mut self,
+        chain_id: &Id,
+        signer: keyring::ed25519::Signer,
+    ) -> Result<(), KmsError> {
+        // TODO(tarcieri):
+        let chain = self.0.get_mut(chain_id).ok_or_else(|| {
+            err!(
+                InvalidKey,
+                "can't add signer {} to unregistered chain: {}",
+                signer.provider(),
+                chain_id
+            )
+        })?;
+
+        chain.keyring.add(signer)
+    }
+
+    /// Register a `Chain` with the registry
+    pub fn register_chain(&mut self, chain: Chain) -> Result<(), KmsError> {
+        let chain_id = chain.id;
+
+        if self.0.insert(chain_id, chain).is_none() {
+            Ok(())
+        } else {
+            // TODO(tarcieri): handle updating the set of registered chains
+            fail!(ConfigError, "chain ID already registered: {}", chain_id);
+        }
+    }
+
+    /// Get information about a particular chain ID (if registered)
+    pub fn get_chain(&self, chain_id: &Id) -> Option<&Chain> {
+        self.0.get(chain_id)
+    }
+}
+
+/// Global registry of blockchain networks known to the KMS
+// NOTE: The `RwLock` is a bit of futureproofing as this data structure is for the
 // most part "immutable". New chains should be registered at boot time.
 // The only case in which this structure may change is in the event of
 // runtime configuration reloading, so the `RwLock` is included as
 // futureproofing for such a feature.
+//
 // See: <https://github.com/tendermint/kms/issues/183>
 #[derive(Default)]
-pub struct Registry(RwLock<BTreeMap<Id, Chain>>);
+pub struct GlobalRegistry(pub(super) RwLock<Registry>);
 
-impl Registry {
+impl GlobalRegistry {
     /// Acquire a read-only (concurrent) lock to the internal chain registry
     pub fn get(&self) -> Guard {
         // TODO(tarcieri): better handle `PoisonError` here?
@@ -40,15 +74,7 @@ impl Registry {
     /// Register a chain with the registry
     pub fn register(&self, chain: Chain) -> Result<(), KmsError> {
         // TODO(tarcieri): better handle `PoisonError` here?
-        let mut chain_map = self.0.write().unwrap();
-
-        let chain_id = chain.id;
-
-        if chain_map.insert(chain_id, chain).is_none() {
-            Ok(())
-        } else {
-            // TODO(tarcieri): handle updating the set of registered chains
-            fail!(ConfigError, "chain ID already registered: {}", chain_id);
-        }
+        let mut registry = self.0.write().unwrap();
+        registry.register_chain(chain)
     }
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -2,7 +2,6 @@ use crate::{
     chain,
     client::Client,
     config::{KmsConfig, ValidatorConfig},
-    keyring,
 };
 use abscissa::{Callable, GlobalConfig};
 use std::{
@@ -46,18 +45,14 @@ impl Callable for StartCommand {
 
         let config = KmsConfig::get_global();
 
-        chain::registry::load_from_config(&config.chain).unwrap_or_else(|e| {
-            status_err!("error initializing chain registry: {}", e);
-            process::exit(1);
-        });
-
-        keyring::load_from_config(&config.providers).unwrap_or_else(|e| {
-            status_err!("couldn't load keyring: {}", e);
+        chain::load_config(&config).unwrap_or_else(|e| {
+            status_err!("error loading configuration: {}", e);
             process::exit(1);
         });
 
         // Should we terminate yet?
         let should_term = Arc::new(AtomicBool::new(false));
+
         // Spawn the validator client threads
         let validator_clients = spawn_validator_clients(&config.validator, &should_term);
         let catch_signals = [signal_hook::SIGTERM, signal_hook::SIGINT];

--- a/src/config/chain/mod.rs
+++ b/src/config/chain/mod.rs
@@ -3,7 +3,7 @@
 mod hook;
 
 pub use self::hook::HookConfig;
-use crate::chain;
+use crate::{chain, keyring};
 use std::path::PathBuf;
 
 /// Chain configuration
@@ -12,8 +12,8 @@ pub struct ChainConfig {
     /// Chain ID of this Tendermint network/chain
     pub id: chain::Id,
 
-    /// Key format configuration
-    pub key_format: chain::key::Format,
+    /// Key serialization format configuration for this chain
+    pub key_format: keyring::Format,
 
     /// Path to chain-specific `priv_validator_state.json` file
     pub state_file: Option<PathBuf>,

--- a/src/keyring/ed25519/signer.rs
+++ b/src/keyring/ed25519/signer.rs
@@ -1,34 +1,41 @@
 use crate::{
-    chain,
     error::{KmsError, KmsErrorKind::*},
     keyring::SigningProvider,
 };
 use signatory::{self, ed25519::Signature, Signer as SignerTrait};
+use std::sync::Arc;
+use tendermint::TendermintKey;
 
 /// Wrapper for an Ed25519 signing provider (i.e. trait object)
+#[derive(Clone)]
 pub struct Signer {
     /// Provider for this signer
     provider: SigningProvider,
 
-    /// Chains this key is authorized to be used from
-    chain_ids: Vec<chain::Id>,
+    /// Tendermint public key
+    public_key: TendermintKey,
 
     /// Signer trait object
-    signer: Box<dyn SignerTrait<Signature>>,
+    signer: Arc<Box<dyn SignerTrait<Signature>>>,
 }
 
 impl Signer {
     /// Create a new signer
     pub fn new(
         provider: SigningProvider,
-        chain_ids: &[chain::Id],
+        public_key: TendermintKey,
         signer: Box<dyn SignerTrait<Signature>>,
     ) -> Self {
         Self {
             provider,
-            chain_ids: chain_ids.to_vec(),
-            signer,
+            public_key,
+            signer: Arc::new(signer),
         }
+    }
+
+    /// Get the Tendermint public key for this signer
+    pub fn public_key(&self) -> TendermintKey {
+        self.public_key
     }
 
     /// Get the provider for this signer
@@ -36,13 +43,11 @@ impl Signer {
         self.provider
     }
 
-    /// Get the chains this signer is authorized to be used on
-    pub fn chain_ids(&self) -> &[chain::Id] {
-        &self.chain_ids
-    }
-
     /// Sign the given message using this signer
     pub fn sign(&self, msg: &[u8]) -> Result<Signature, KmsError> {
-        Ok(signatory::sign(self.signer.as_ref(), msg).map_err(|e| err!(SigningError, "{}", e))?)
+        Ok(self
+            .signer
+            .sign(msg)
+            .map_err(|e| err!(SigningError, "{}", e))?)
     }
 }

--- a/src/keyring/ed25519/softsign.rs
+++ b/src/keyring/ed25519/softsign.rs
@@ -1,20 +1,24 @@
-/// ed25519-dalek software-based signer
-///
-/// This is mainly intended for testing/CI. Ideally real validators will use HSMs
-use signatory::{ed25519, encoding::Decode, PublicKeyed};
-use signatory_dalek::Ed25519Signer;
-use subtle_encoding::IDENTITY;
+//! ed25519-dalek software-based signer
+//!
+//! This is mainly intended for testing/CI. Ideally real validators will use HSMs
 
 use super::Signer;
 use crate::{
+    chain,
     config::provider::softsign::SoftSignConfig,
     error::{KmsError, KmsErrorKind::*},
-    keyring::{KeyRing, SigningProvider},
+    keyring::SigningProvider,
 };
+use signatory::{ed25519, encoding::Decode, PublicKeyed};
+use signatory_dalek::Ed25519Signer;
+use subtle_encoding::IDENTITY;
 use tendermint::TendermintKey;
 
 /// Create software-backed Ed25519 signer objects from the given configuration
-pub fn init(keyring: &mut KeyRing, configs: &[SoftSignConfig]) -> Result<(), KmsError> {
+pub fn init(
+    chain_registry: &mut chain::Registry,
+    configs: &[SoftSignConfig],
+) -> Result<(), KmsError> {
     for config in configs {
         let seed =
             ed25519::Seed::decode_from_file(config.path.as_path(), IDENTITY).map_err(|e| {
@@ -26,15 +30,14 @@ pub fn init(keyring: &mut KeyRing, configs: &[SoftSignConfig]) -> Result<(), Kms
                 )
             })?;
 
-        let provider = Box::new(Ed25519Signer::from(&seed));
-
+        let provider = Ed25519Signer::from(&seed);
         // TODO(tarcieri): support for adding account keys into keyrings
         let public_key = TendermintKey::ConsensusKey(provider.public_key()?.into());
+        let signer = Signer::new(SigningProvider::SoftSign, public_key, Box::new(provider));
 
-        keyring.add(
-            public_key,
-            Signer::new(SigningProvider::SoftSign, &config.chain_ids, provider),
-        )?;
+        for chain_id in &config.chain_ids {
+            chain_registry.add_to_keyring(chain_id, signer.clone())?;
+        }
     }
 
     Ok(())

--- a/src/keyring/format.rs
+++ b/src/keyring/format.rs
@@ -1,6 +1,5 @@
 //! Chain-specific key configuration
 
-use super::{Id, REGISTRY};
 use tendermint::TendermintKey;
 
 /// Options for how keys for this chain are represented
@@ -36,12 +35,4 @@ impl Format {
             Format::Hex => public_key.to_hex(),
         }
     }
-}
-
-/// Serialize a key according to chain-specific serialization rules
-pub fn serialize(chain_id: Id, public_key: TendermintKey) -> Option<String> {
-    let registry = REGISTRY.get();
-    registry
-        .chain(chain_id)
-        .map(|chain| chain.key_format.serialize(public_key))
 }


### PR DESCRIPTION
Moves from a single global keyring to chain-specific keyrings, where keys/signers can be potentially shared across chains if desired.

This enables true multitenancy for supporting multiple chains with a single KMS instance, and reloves lingering questions around the access control model, namely that each connection has an associated chain ID, and signing operations are isolated to that chain's keyring.