### PR TITLE
tendermint-rs: Disallow a block height of 0

### DIFF
--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -35,7 +35,7 @@ pub struct Proposal {
 // TODO(tony): custom derive proc macro for this e.g. `derive(ParseBlockHeight)`
 impl block::ParseHeight for Proposal {
     fn parse_block_height(&self) -> Result<block::Height, Error> {
-        block::Height::parse(self.height)
+        block::Height::try_from_i64(self.height)
     }
 }
 
@@ -74,7 +74,7 @@ impl chain::ParseId for CanonicalProposal {
 
 impl block::ParseHeight for CanonicalProposal {
     fn parse_block_height(&self) -> Result<block::Height, Error> {
-        block::Height::parse(self.height)
+        block::Height::try_from_i64(self.height)
     }
 }
 
@@ -136,7 +136,7 @@ impl SignableMsg for SignProposalRequest {
     fn consensus_state(&self) -> Option<ConsensusState> {
         match self.proposal {
             Some(ref p) => Some(ConsensusState {
-                height: match block::Height::parse(p.height) {
+                height: match block::Height::try_from_i64(p.height) {
                     Ok(h) => h,
                     Err(_err) => return None, // TODO(tarcieri): return an error?
                 },

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -46,7 +46,7 @@ impl Vote {
 
 impl block::ParseHeight for Vote {
     fn parse_block_height(&self) -> Result<block::Height, Error> {
-        block::Height::parse(self.height)
+        block::Height::try_from_i64(self.height)
     }
 }
 
@@ -92,7 +92,7 @@ impl chain::ParseId for CanonicalVote {
 
 impl block::ParseHeight for CanonicalVote {
     fn parse_block_height(&self) -> Result<block::Height, Error> {
-        block::Height::parse(self.height)
+        block::Height::try_from_i64(self.height)
     }
 }
 
@@ -157,7 +157,7 @@ impl SignableMsg for SignVoteRequest {
     fn consensus_state(&self) -> Option<ConsensusState> {
         match self.vote {
             Some(ref v) => Some(ConsensusState {
-                height: match block::Height::parse(v.height) {
+                height: match block::Height::try_from_i64(v.height) {
                     Ok(h) => h,
                     Err(_err) => return None, // TODO(tarcieri): return an error?
                 },

--- a/tendermint-rs/src/block/height.rs
+++ b/tendermint-rs/src/block/height.rs
@@ -8,13 +8,14 @@ use std::{
 
 /// Block height for a particular chain (i.e. number of blocks created since
 /// the chain began)
-#[derive(Copy, Clone, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Height(pub u64);
 
 impl Height {
     /// Parse height from the integer type used in Amino messages
-    pub fn parse(n: i64) -> Result<Self, Error> {
-        if n >= 0 {
+    pub fn try_from_i64(n: i64) -> Result<Self, Error> {
+        // Minimum height is 1
+        if n > 0 {
             Ok(Height(n as u64))
         } else {
             Err(Error::OutOfRange)
@@ -38,6 +39,12 @@ impl Debug for Height {
     }
 }
 
+impl Default for Height {
+    fn default() -> Self {
+        Height(1)
+    }
+}
+
 impl Display for Height {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
@@ -46,7 +53,7 @@ impl Display for Height {
 
 impl From<i64> for Height {
     fn from(n: i64) -> Height {
-        Self::parse(n).unwrap()
+        Self::try_from_i64(n).unwrap()
     }
 }
 
@@ -72,7 +79,7 @@ impl FromStr for Height {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Error> {
-        Ok(Self::from(s.parse::<u64>().map_err(|_| Error::Parse)?))
+        Self::try_from_i64(s.parse::<i64>().map_err(|_| Error::Parse)?)
     }
 }
 
@@ -103,6 +110,6 @@ mod tests {
 
     #[test]
     fn increment_by_one() {
-        assert_eq!(Height::default().increment().value(), 1);
+        assert_eq!(Height::default().increment().value(), 2);
     }
 }


### PR DESCRIPTION
Tendermint itself says: "Height must be greater than 0" (code -32603)