### PR TITLE
tendermint-rs v0.7.0-alpha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.6.0"
+version = "0.7.0-alpha1"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1196,7 +1196,7 @@ dependencies = [
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.6.0",
+ "tendermint 0.7.0-alpha1",
  "tiny-bip39 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ signatory-dalek = "0.11"
 signatory-secp256k1 = "0.11"
 subtle = "2"
 subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
-tendermint = { version = "0.6", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
+tendermint = { version = "0.7.0-alpha1", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
 tiny-bip39 = "0.6"
 wait-timeout = "0.2"
 yubihsm = { version = "0.22", features = ["setup", "usb"], optional = true }

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.6.0" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.7.0-alpha1" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"


### PR DESCRIPTION
Prepping a v0.7.0 release of the `tendermint` crate, with the goal of testing tmkms with the current version live on both `cosmoshub-1` and on the testnet prior to the upgrade.

Main notable PRs are #232, #234, #235. Furthermore #228 contains some important changes but has not been tested in a KMS release yet.