### PR TITLE
tmkms v0.6.0-alpha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.5.0"
+version = "0.6.0-alpha1"
 dependencies = [
  "abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.5.0"
+version     = "0.6.0-alpha1"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"


### PR DESCRIPTION
Alpha release which includes:

- Chain-specific keyrings / multitenancy (#232)
- Max height support (#238)
- `tendermint` crate changes (#240)