### PR TITLE
Cargo.toml: add docs.rs metadata to document all features (fixes #244)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,3 +61,6 @@ yubihsm-mock = ["yubihsm/mockhsm"]
 # Enable integer overflow checks in release builds for security reasons
 [profile.release]
 overflow-checks = true
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
Otherwise the docs don't build