### PR TITLE
tendermint-rs v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,7 +1172,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.7.0-alpha1"
+version = "0.7.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1263,7 +1263,7 @@ dependencies = [
  "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.7.0-alpha1",
+ "tendermint 0.7.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ signatory-dalek = "0.11"
 signatory-secp256k1 = "0.11"
 subtle = "2"
 subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
-tendermint = { version = "0.7.0-alpha1", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
+tendermint = { version = "0.7", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
 tiny-bip39 = "0.6"
 wait-timeout = "0.2"
 yubihsm = { version = "0.22", features = ["setup", "usb"], optional = true }

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.7.0] (2019-04-24)
+
+This release is compatible with [tendermint v0.31]
+
+- Initial JSONRPC over HTTP client + `/broadcast_tx_*` endpoints ([#243])
+- Initial RPC support ([#235])
+- Disallow a block height of 0 ([#234])
+
 ## [0.6.0] (2019-04-16)
 
 This release is compatible with [tendermint v0.31]
@@ -58,6 +66,10 @@ This release is compatible with [tendermint v0.28]
 
 - Initial release
 
+[0.7.0]: https://github.com/tendermint/kms/pull/247
+[#243]: https://github.com/tendermint/kms/pull/243
+[#235]: https://github.com/tendermint/kms/pull/235
+[#234]: https://github.com/tendermint/kms/pull/234
 [0.6.0]: https://github.com/tendermint/kms/pull/229
 [tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0310
 [#228]: https://github.com/tendermint/kms/pull/228

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.7.0-alpha1" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.7.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -1,7 +1,8 @@
 //! Tendermint is a high-performance blockchain consensus engine that powers
 //! Byzantine fault tolerant applications written in any programming language.
-//! This crate provides types for representing information about Tendermint
-//! blockchain networks, including chain IDs, block IDs, and block heights.
+//! This crate provides core types for representing information about Tendermint
+//! blockchain networks, including chain information types, secret connections,
+//! and remote procedure calls (JSONRPC).
 
 #![deny(
     warnings,
@@ -14,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.6.0"
+    html_root_url = "https://docs.rs/tendermint/0.7.0"
 )]
 
 #[cfg(feature = "amino-types")]


### PR DESCRIPTION
This release is compatible with [tendermint v0.31](https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0310)

- Initial JSONRPC over HTTP client + `/broadcast_tx_*` endpoints (#243)
- Initial RPC support (#235)
- Disallow a block height of 0 (#234)