### PR TITLE
Upgrade to Abscissa 0.1.0-pre.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,33 +2,37 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa"
-version = "0.0.6"
+version = "0.1.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "canonical-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abscissa_derive 0.1.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secrecy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "abscissa_derive"
-version = "0.0.2"
+version = "0.1.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -89,30 +93,39 @@ dependencies = [
 
 [[package]]
 name = "atomicwrites"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "autocfg"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "backtrace"
-version = "0.3.15"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -120,8 +133,8 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -138,17 +151,17 @@ name = "bit-set"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -174,7 +187,7 @@ name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -190,16 +203,16 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.2.0"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "block-padding"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -231,17 +244,17 @@ dependencies = [
 
 [[package]]
 name = "canonical-path"
-version = "0.1.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cc"
-version = "1.0.26"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -249,9 +262,9 @@ name = "chrono"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -260,7 +273,7 @@ name = "clear_on_drop"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -268,7 +281,7 @@ name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -297,14 +310,14 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -336,7 +349,7 @@ name = "dirs"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -347,7 +360,7 @@ version = "1.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -363,7 +376,7 @@ name = "failure"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -372,10 +385,10 @@ name = "failure_derive"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -414,6 +427,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "gumdrop_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,10 +474,10 @@ name = "hidapi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -464,7 +506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hyper"
-version = "0.10.15"
+version = "0.10.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -495,19 +537,8 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "isatty"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -520,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -539,11 +570,11 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hidapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -558,12 +589,12 @@ dependencies = [
  "ledger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.51"
+version = "0.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -572,7 +603,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "libusb-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -581,7 +612,7 @@ name = "libusb-sys"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -606,7 +637,7 @@ name = "log"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -624,25 +655,25 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "nix"
-version = "0.13.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -653,24 +684,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num-integer"
-version = "0.1.39"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "num_cpus"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "numtoa"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "once_cell"
@@ -699,7 +739,7 @@ name = "parking_lot_core"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -727,7 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.27"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -750,7 +790,7 @@ dependencies = [
  "digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -766,7 +806,7 @@ name = "quote"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -775,7 +815,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -786,13 +826,13 @@ name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -804,7 +844,7 @@ name = "rand_chacha"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -839,10 +879,10 @@ dependencies = [
 
 [[package]]
 name = "rand_jitter"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -854,7 +894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -865,7 +905,7 @@ name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -891,6 +931,14 @@ version = "0.1.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,9 +962,9 @@ name = "ring"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -924,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -937,7 +985,7 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -957,10 +1005,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "secp256k1"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -978,20 +1035,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.90"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -999,9 +1056,9 @@ name = "serde_json"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1028,44 +1085,97 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.1.8"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arc-swap 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "signatory"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signatory"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle-encoding 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "signatory-dalek"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signatory-ledger-tm"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ledger-tendermint 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "signatory-secp256k1"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "secp256k1 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signature"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "signature_derive"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1095,17 +1205,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "subtle-encoding"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1113,39 +1223,39 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.15.32"
+version = "0.15.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "synstructure"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "tai64"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1159,11 +1269,11 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1180,22 +1290,22 @@ dependencies = [
  "digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory-dalek 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle-encoding 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tai64 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory-dalek 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tai64 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1209,11 +1319,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
  "redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1236,46 +1365,45 @@ dependencies = [
 name = "tmkms"
 version = "0.6.0-alpha1"
 dependencies = [
- "abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "atomicwrites 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abscissa 0.1.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ledger-tendermint 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory-dalek 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory-secp256k1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle-encoding 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory-dalek 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory-ledger-tm 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory-secp256k1 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tendermint 0.7.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "yubihsm 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yubihsm 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "toml"
-version = "0.4.10"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1342,7 +1470,7 @@ name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1360,7 +1488,7 @@ name = "wait-timeout"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1383,9 +1511,26 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -1393,77 +1538,64 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "yubihsm"
-version = "0.22.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "block-modes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmac 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gaunt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "getrandom 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libusb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "signature_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zeroize"
-version = "0.4.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "zeroize"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "zeroize"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "0.1.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [metadata]
-"checksum abscissa 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "159a56ddefc6675d47b8063aada781ca621be8c7ac3adfc6520647024fd3461b"
-"checksum abscissa_derive 0.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ef4cd3ff1140f337a6d49256197c1455e2fb97ed76b2f220606809974f128814"
+"checksum abscissa 0.1.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ffe01067119b93ef2b2b6f5b00b66b1fb148266db1498bf686eea9780acc8447"
+"checksum abscissa_derive 0.1.0-pre.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a14a6256419bc6613a7806388f50554e387cebc388007a1d2a47f9ef6c088341"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
 "checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
@@ -1471,34 +1603,35 @@ dependencies = [
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
-"checksum atomicwrites 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a3420b33cdefd3feb223dddc23739fc05cc034eb0f2be792c763e3d89e1eb6e3"
-"checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
-"checksum backtrace 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f106c02a3604afcdc0df5d36cc47b44b55917dbaf3d808f71c163a0ddba64637"
+"checksum atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c4e1aa99513c90202b4b04cfbe3c9d51dd914f2e26215a4caa76574b00bb6393"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
+"checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"
+"checksum backtrace 0.3.30 (registry+https://github.com/rust-lang/crates.io-index)" = "ada4c783bb7e7443c14e0480f429ae2cc99da95065aeab7ee1b81ada0419404f"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bit-set 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e1e6fb1c9e3d6fcdec57216a74eaa03e41f52a22f13a16438251d8e88b89da"
-"checksum bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
-"checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum bit-vec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a4523a10839ffae575fb08aa3423026c8cb4687eef43952afb956229d4f246f7"
+"checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-cipher-trait 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
-"checksum block-modes 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "283fa06a14026feac8912bf35328fc074f5d68907fd4b9cccad5658a3fc62a30"
-"checksum block-padding 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d75255892aeb580d3c566f213a2b6fdc1c66667839f45719ee1d30ebf2aea591"
+"checksum block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
+"checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum canonical-path 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa83b9f518bd3943b6757de8489c7756566df78026771955b90ecb87295a5dc"
-"checksum cc 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "389803e36973d242e7fecb092b2de44a3d35ac62524b3b9339e51d577d668e02"
-"checksum cfg-if 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11d43355396e872eefb45ce6342e4374ed7bc2b3a502d1b28e36d6e23c05d1f4"
+"checksum canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e9e01327e6c86e92ec72b1c798d4a94810f147209bbe3ffab6a86954937a6f"
+"checksum cc 1.0.35 (registry+https://github.com/rust-lang/crates.io-index)" = "5e5f3fee5eeb60324c2781f1e41286bdee933850fff9b3c672587fed5ec58c83"
+"checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cmac 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6f4a435124bcc292eba031f1f725d7abacdaf13cbf9f935450e8c45aa9e96cad"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum crypto-mac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
-"checksum curve25519-dalek 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e1f8a6fc0376eb52dc18af94915cc04dfdf8353746c0e8c550ae683a0815e5c1"
+"checksum curve25519-dalek 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5d4b820e8711c211745880150f5fac78ab07d6e3851d8ce9f5a02cedc199174c"
 "checksum dbl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "28dc203b75decc900220c4d9838e738d08413e663c26826ba92b669bed1d0795"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
@@ -1512,23 +1645,25 @@ dependencies = [
 "checksum gaunt 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0348d3b5fbd30311ea16ce573f137c689e5a3fb2d7b037eefe0a6384143298b6"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum getrandom 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8d1dffef07351aafe6ef177e4dd2b8dcf503e6bc765dea3b0de9ed149a3db1ec"
+"checksum gumdrop 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "395c7c79599167d04e7349ee60cc6cb14a28dfebaf922b4dc41603a7b18c3b28"
+"checksum gumdrop_derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c43663fd6604d9065f5cd26ae7a0301491fd941ad29b0a01665a6be3a1ddbd"
 "checksum hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hidapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25440089a47b7c63b7a3515d1cdfcd0ac3d649fdc360540944e05c4e7899b4fe"
 "checksum hkdf 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a89c4638cf4e02d9db29750659d2af13d9001b508716f77d4693ec8a1f8bda8"
 "checksum hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f127a908633569f208325f86f71255d3363c79721d7f9fe31cd5569908819771"
 "checksum httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e8734b0cfd3bc3e101ec59100e101c2eecd19282202e87808b3037b442777a83"
-"checksum hyper 0.10.15 (registry+https://github.com/rust-lang/crates.io-index)" = "df0caae6b71d266b91b4a83111a61d2b94ed2e2bea024c532b933dcff867e58c"
+"checksum hyper 0.10.16 (registry+https://github.com/rust-lang/crates.io-index)" = "0a0652d9a2609a968c14be1a9ea00bf4b1d64e2e1f53a1b51b6fff3a6e829273"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
-"checksum isatty 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e31a8281fc93ec9693494da65fbf28c0c2aa60a2eaec25dc58e2f31952e95edc"
 "checksum itertools 0.7.11 (registry+https://github.com/rust-lang/crates.io-index)" = "0d47946d458e94a1b7bcabbf6521ea7c037062c81f534615abcad76e84d4970d"
-"checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum ledger 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6c9a2f47929b010a64a4bf9cdfe03b0d02175d44db0b91e16283f5a4a731d52c"
 "checksum ledger-tendermint 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "798701caf0fe437d7d72939eed5f18ae187e9c414eb5f4e9b8eeceaa16f99a23"
-"checksum libc 0.2.51 (registry+https://github.com/rust-lang/crates.io-index)" = "bedcc7a809076656486ffe045abeeac163da1b558e963a31e29fbfbeba916917"
+"checksum libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "6281b86796ba5e4366000be6e9e18bf35580adf9e63fbe2294aadb587613a319"
 "checksum libusb 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f990ddd929cbe53de4ecd6cf26e1f4e0c5b9796e4c629d9046570b03738aa53"
 "checksum libusb-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c53b6582563d64ad3e692f54ef95239c3ea8069e82c9eb70ca948869a7ad767"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
@@ -1536,12 +1671,13 @@ dependencies = [
 "checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
-"checksum nix 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d37e713a259ff641624b6cb20e3b12b2952313ba36b6823c0f16e6cfd9e5de17"
 "checksum nix 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46f0f3210768d796e8fa79ec70ee6af172dacbe7147f5e69be5240a47778302b"
+"checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
-"checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
-"checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
+"checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
+"checksum num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6ba9a427cfca2be13aa6f6403b0b7e7368fe982bfa16fccc450ce74c46cd9b32"
 "checksum num_cpus 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1a23f0ed30a54abaa0c7e83b1d2d87ada7c3c23078d1d87815af3e3b6385fbba"
+"checksum numtoa 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8f8bdf33df195859076e54ab11ee78a1b208382d3a26ec40d142ffc1ecc49ef"
 "checksum once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
@@ -1549,7 +1685,7 @@ dependencies = [
 "checksum pbkdf2 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "006c038a43a45995a9670da19e67600114740e8511d4333bf97a56e66a7542d9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
-"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
+"checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum prost-amino 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "04c5c4189b6c3e054c064a0c88d51f9379db268d5f8f6ea6afffd3849aeca1a7"
 "checksum prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6376b995db84c9791ab5d3f7bc3e315f8bc1a55fe139a0a2da24aa24e27de809"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
@@ -1561,49 +1697,58 @@ dependencies = [
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.54 (registry+https://github.com/rust-lang/crates.io-index)" = "12229c14a0f65c4f1cb046a3b52047cdd9da1f4b30f8a39c5063c8bae515e252"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum redox_users 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe5204c3a17e97dde73f285d49be585df59ed84b50a872baf416e73b62c3828"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum ring 0.14.6 (registry+https://github.com/rust-lang/crates.io-index)" = "426bc186e3e95cac1e4a4be125a4aca7e84c2d616ffc02244eef36e2a60a093c"
-"checksum rustc-demangle 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc78bfd5acd7bf3e89cffcf899e5cb1a52d6fafa8dec2739ad70c9577a57288"
+"checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-"checksum ryu 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "eb9e9b8cde282a9fe6a42dd4681319bfb63f121b8a8ee9439c6f4107e58a46f7"
+"checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
-"checksum secp256k1 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfaccd3a23619349e0878d9a241f34b1982343cdf67367058cd7d078d326b63e"
+"checksum secp256k1 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fb1f2c586f44331cd22561405885bb55d869e042715f29d019dbe68558b4f7ec"
+"checksum secrecy 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ca0a45d09dbe5add123ade41bb7c4ad697a2544c7834a77bc145135c80c5f30a"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-"checksum serde 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "aa5f7c20820475babd2c077c3ab5f8c77a31c15e16ea38687b4c02d3e48680f4"
-"checksum serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)" = "58fc82bec244f168b23d1963b45c8bf5726e9a15a9d146a067f9081aeed2de79"
+"checksum serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "32746bf0f26eab52f06af0d0aa1984f641341d06d8d673c693871da2d188c9be"
+"checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 "checksum sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4d8bfd0e469f417657573d8451fb33d16cfe0989359b93baf3a1ffc639543d"
-"checksum signal-hook 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "97a47ae722318beceb0294e6f3d601205a1e6abaa4437d9d33e3a212233e3021"
-"checksum signatory 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e282f6c031ca56210bb82a9aec3e5c1638345367cbab0208440e6a5a9493552f"
-"checksum signatory-dalek 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b5ed7678eaeb98cb23e1efdb5e961021b02d3bd9f8bab4d4e30c53ebb3dd50"
-"checksum signatory-secp256k1 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57765ca2c5615453b345477546ddc697921f3c8fc71fd1ffc4edc2ffa0453f1d"
+"checksum signal-hook 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "72ab58f1fda436857e6337dcb6a5aaa34f16c5ddc87b3a8b6ef7a212f90b9c5a"
+"checksum signal-hook-registry 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cded4ffa32146722ec54ab1f16320568465aa922aa9ab4708129599740da85d7"
+"checksum signatory 0.11.5 (registry+https://github.com/rust-lang/crates.io-index)" = "45329515bd428e81eb5b08c1629fb8099d79ea8ce8e1b9f3b68ee766be82f66d"
+"checksum signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "92785dea71e4d1d2b2c5dceee9cdaf809a177e3865b29d246b0314f4ecc110b0"
+"checksum signatory-dalek 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ad3891c134888db96183ebfa6d1f6bf5b4c566b3a43d40d219cd5959620bbcdd"
+"checksum signatory-ledger-tm 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d1175610eb08aa9147e5317c7b3358d3c8a78adaac9c2c940bd1fc92df8e0f12"
+"checksum signatory-secp256k1 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "97a10de0732f951ceb8401ecd60ab016ca5ee7eb988e3819b3b23ae3611bb9f4"
+"checksum signature 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "144b5d1138a4339c839603f15f69ffe3195e51b5caa92f815b47d4553db47337"
+"checksum signature_derive 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "21de160b58596767f60a674960253756643aa84674a1afa813148abb9a91815e"
 "checksum simplelog 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e95345f185d5adeb8ec93459d2dc99654e294cc6ccf5b75414d8ea262de9a13"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum spin 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44363f6f51401c34e7be73db0db371c04705d35efbe9f7d6082e03a921a32c55"
 "checksum subtle 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
-"checksum subtle 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "702662512f3ddeb74a64ce2fbbf3707ee1b6bb663d28bb054e0779bbc720d926"
-"checksum subtle-encoding 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "83357cf892635c468b754d4bd3d99f904464d1d9d3eeb53fab92c5bc1ab82c04"
+"checksum subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "01dca13cf6c3b179864ab3292bd794e757618d35a7766b7c46050c614ba00829"
+"checksum subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "661a0cd6c74eca6fab1a5b452d9f2201fbac9004e958bd70d5b4f288b1aed479"
 "checksum syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)" = "261ae9ecaa397c42b960649561949d69311f08eeaea86a65696e6e46517cf741"
-"checksum syn 0.15.32 (registry+https://github.com/rust-lang/crates.io-index)" = "846620ec526c1599c070eff393bfeeeb88a93afa2513fc3b49f1fea84cf7b0ed"
-"checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum tai64 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aec79c84b38f055fd98013da804b912a165d9691a3fd27fefabc8b46ed8b6901"
+"checksum syn 0.15.35 (registry+https://github.com/rust-lang/crates.io-index)" = "641e117d55514d6d918490e47102f7e08d096fdde360247e4a10f7a91a8478d3"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
+"checksum tai64 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5f442aa71b3f67bc82699063a608b32331ab5b0fcdd078694d3d4b84716b0942"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-"checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
+"checksum tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7dc4738f2e68ed2855de5ac9cdbe05c9216773ecde4739b2f095002ab03a13ef"
 "checksum term 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c1c5676413eaeb1ea35300a0224416f57abc3bd251657e0fafc12c47ff98c060"
-"checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+"checksum toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b8c96d7873fa7ef8bdeb3a9cda3ac48389b4154f32b9803b4bc26220b677b039"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
@@ -1620,10 +1765,10 @@ dependencies = [
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "f10e386af2b13e47c89e7236a7a14a086791a2b88ebad6df9bf42040195cf770"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
-"checksum yubihsm 0.22.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b61bfeae6f2ff19327d5ce0c9263afd7f80bda2c3fc5ffd9afd98146d0e72457"
-"checksum zeroize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d7ddffec9ddef28ba2d6359bcbf0dc6772e62b112bc103dfb1e6fab46cd47c39"
-"checksum zeroize 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8ddfeb6eee2fb3b262ef6e0898a52b7563bb8e0d5955a313b3cf2f808246ea14"
-"checksum zeroize 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e68403b858b6af538b11614e62dfe9ab2facba9f13a0cafb974855cfb495ec95"
-"checksum zeroize_derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b3f07490820219949839d0027b965ffdd659d75be9220c00798762e36c6cd281"
+"checksum yubihsm 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)" = "309e48dff6c33d549962d5648955659cb124ddfe99f690bd36e153dc676960df"
+"checksum zeroize 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e2ea4afc22e9497e26b42bf047083c30f7e3ca566f3bcd7187f83d18b327043"
+"checksum zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afd1469e4bbca3b96606d26ba6e9bd6d3aed3b1299c82b92ec94377d22d78dbc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,37 +16,40 @@ members = [".", "tendermint-rs"]
 [badges]
 circle-ci = { repository = "tendermint/kms" }
 
+[dependencies.abscissa]
+version = "0.1.0-pre.1"
+default-features = false
+features = ["application", "signals", "secrets", "time"]
+
 [dependencies]
-abscissa = "0.0.6"
-abscissa_derive = "0.0.2"
 atomicwrites = "0.2"
 byteorder = "1.2"
 bytes = "0.4"
 chrono = "0.4"
 failure = "0.1"
-failure_derive = "0.1"
+gumdrop = "0.5"
 hkdf = "0.7"
 hmac = "0.7"
 lazy_static = "1"
-ledger-tendermint = { version = "0.4.0", optional = true }
+log = "0.4"
 prost-amino = "0.4.0"
 prost-amino-derive = "0.4.0"
 rand_os = "0.1"
-serde = "1"
-serde_derive = "1"
+serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.8"
 signal-hook = "0.1.7"
-signatory = { version = "0.11.1", features = ["ed25519", "ecdsa"] }
-signatory-dalek = "0.11"
-signatory-secp256k1 = "0.11"
+signatory = { version = "0.12", features = ["ed25519", "ecdsa"] }
+signatory-dalek = "0.12"
+signatory-secp256k1 = "0.12"
+signatory-ledger-tm = { version = "0.12", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
 tendermint = { version = "0.7", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
 tiny-bip39 = "0.6"
 wait-timeout = "0.2"
-yubihsm = { version = "0.22", features = ["setup", "usb"], optional = true }
-zeroize = "0.5"
+yubihsm = { version = "0.25", features = ["setup", "usb"], optional = true }
+zeroize = "0.9"
 
 [dev-dependencies]
 tempfile = "3"
@@ -55,7 +58,7 @@ rand = "0.6" # TODO: switch to the getrandom crate
 [features]
 default = []
 softsign = []
-ledgertm = ["ledger-tendermint"]
+ledgertm = ["signatory-ledger-tm"]
 yubihsm-mock = ["yubihsm/mockhsm"]
 
 # Enable integer overflow checks in release builds for security reasons

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,25 +1,103 @@
 //! Abscissa `Application` for the KMS
 
-use abscissa::{self, Application, LoggingConfig};
-
 use crate::{commands::KmsCommand, config::KmsConfig};
+use abscissa::{application, Application, FrameworkError, LoggingConfig, StandardPaths};
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Application state
+    pub static ref APPLICATION: application::Lock<KmsApplication> = application::Lock::default();
+}
+
+/// Obtain a read-only (multi-reader) lock on the application state.
+///
+/// Panics if the application state has not been initialized.
+pub fn app_reader() -> application::lock::Reader<KmsApplication> {
+    APPLICATION.read()
+}
+
+/// Obtain an exclusive mutable lock on the application state.
+pub fn app_writer() -> application::lock::Writer<KmsApplication> {
+    APPLICATION.write()
+}
+
+/// Obtain a read-only (multi-reader) lock on the application configuration.
+///
+/// Panics if the application configuration has not been loaded.
+pub fn app_config() -> abscissa::config::Reader<KmsApplication> {
+    abscissa::config::Reader::new(&APPLICATION)
+}
 
 /// The `tmkms` application
 #[derive(Debug)]
-pub struct KmsApplication;
+pub struct KmsApplication {
+    /// Application configuration.
+    config: Option<KmsConfig>,
 
-impl KmsApplication {
-    /// Boot the application
-    // TODO: use the upstream implementation of this method
-    pub fn boot() {
-        abscissa::boot(KmsApplication)
+    /// Application state.
+    state: application::State<Self>,
+}
+
+impl Default for KmsApplication {
+    fn default() -> Self {
+        Self {
+            config: None,
+            state: application::State::default(),
+        }
     }
 }
 
 impl Application for KmsApplication {
+    /// Entrypoint command for this application.
     type Cmd = KmsCommand;
-    type Config = KmsConfig;
 
+    /// Application configuration.
+    type Cfg = KmsConfig;
+
+    /// Paths to resources within the application.
+    type Paths = StandardPaths;
+
+    /// Accessor for application configuration.
+    fn config(&self) -> Option<&KmsConfig> {
+        self.config.as_ref()
+    }
+
+    /// Borrow the application state immutably.
+    fn state(&self) -> &application::State<Self> {
+        &self.state
+    }
+
+    /// Borrow the application state mutably.
+    fn state_mut(&mut self) -> &mut application::State<Self> {
+        &mut self.state
+    }
+
+    /// Register all components used by this application.
+    ///
+    /// If you would like to add additional components to your application
+    /// beyond the default ones provided by the framework, this is the place
+    /// to do so.
+    fn register_components(&mut self, command: &Self::Cmd) -> Result<(), FrameworkError> {
+        let components = self.framework_components(command)?;
+        self.state.components.register(components)
+    }
+
+    /// Post-configuration lifecycle callback.
+    ///
+    /// Called regardless of whether config is loaded to indicate this is the
+    /// time in app lifecycle when configuration would be loaded if
+    /// possible.
+    fn after_config(&mut self, config: Option<Self::Cfg>) -> Result<(), FrameworkError> {
+        // Provide configuration to all component `after_config()` handlers
+        for component in self.state.components.iter_mut() {
+            component.after_config(config.as_ref())?;
+        }
+
+        self.config = config;
+        Ok(())
+    }
+
+    /// Get logging configuration from command-line options
     fn logging_config(&self, command: &KmsCommand) -> LoggingConfig {
         if command.verbose() {
             LoggingConfig::verbose()

--- a/src/bin/tmkms/main.rs
+++ b/src/bin/tmkms/main.rs
@@ -1,9 +1,8 @@
 //! Main entry point for the `tmkms` executable
 
-extern crate tmkms;
-use tmkms::KmsApplication;
+use tmkms::application::APPLICATION;
 
 /// Boot the `tmkms` application
 fn main() {
-    KmsApplication::boot();
+    abscissa::boot(&APPLICATION);
 }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -11,7 +11,7 @@ pub use self::{
 };
 use crate::{
     config::{chain::ChainConfig, KmsConfig},
-    error::KmsError,
+    error::Error,
     keyring::{self, KeyRing},
 };
 use std::{path::PathBuf, sync::Mutex};
@@ -31,7 +31,7 @@ pub struct Chain {
 
 impl Chain {
     /// Attempt to create a `Chain` state from the given configuration
-    pub fn from_config(config: &ChainConfig) -> Result<Chain, KmsError> {
+    pub fn from_config(config: &ChainConfig) -> Result<Chain, Error> {
         let state_file = match config.state_file {
             Some(ref path) => path.to_owned(),
             None => PathBuf::from(&format!("{}_priv_validator_state.json", config.id)),
@@ -62,7 +62,7 @@ impl Chain {
 }
 
 /// Initialize the chain registry from the configuration file
-pub fn load_config(config: &KmsConfig) -> Result<(), KmsError> {
+pub fn load_config(config: &KmsConfig) -> Result<(), Error> {
     for config in &config.chain {
         REGISTRY.register(Chain::from_config(config)?)?;
     }

--- a/src/chain/registry.rs
+++ b/src/chain/registry.rs
@@ -2,12 +2,14 @@
 
 use super::{Chain, Guard, Id};
 use crate::{
-    error::{KmsError, KmsErrorKind::*},
+    error::{Error, ErrorKind::*},
     keyring,
 };
+use lazy_static::lazy_static;
 use std::{collections::BTreeMap, sync::RwLock};
 
 lazy_static! {
+    /// State of Tendermint blockchain networks
     pub static ref REGISTRY: GlobalRegistry = GlobalRegistry::default();
 }
 
@@ -21,7 +23,7 @@ impl Registry {
         &mut self,
         chain_id: &Id,
         signer: keyring::ed25519::Signer,
-    ) -> Result<(), KmsError> {
+    ) -> Result<(), Error> {
         // TODO(tarcieri):
         let chain = self.0.get_mut(chain_id).ok_or_else(|| {
             err!(
@@ -36,7 +38,7 @@ impl Registry {
     }
 
     /// Register a `Chain` with the registry
-    pub fn register_chain(&mut self, chain: Chain) -> Result<(), KmsError> {
+    pub fn register_chain(&mut self, chain: Chain) -> Result<(), Error> {
         let chain_id = chain.id;
 
         if self.0.insert(chain_id, chain).is_none() {
@@ -72,7 +74,7 @@ impl GlobalRegistry {
     }
 
     /// Register a chain with the registry
-    pub fn register(&self, chain: Chain) -> Result<(), KmsError> {
+    pub fn register(&self, chain: Chain) -> Result<(), Error> {
         // TODO(tarcieri): better handle `PoisonError` here?
         let mut registry = self.0.write().unwrap();
         registry.register_chain(chain)

--- a/src/chain/state/hook.rs
+++ b/src/chain/state/hook.rs
@@ -2,8 +2,9 @@
 
 use crate::{
     config::chain::HookConfig,
-    error::{KmsError, KmsErrorKind::HookError},
+    error::{Error, ErrorKind::HookError},
 };
+use serde::Deserialize;
 use std::{process::Command, time::Duration};
 use tendermint::block;
 use wait_timeout::ChildExt;
@@ -16,7 +17,7 @@ const DEFAULT_TIMEOUT_SECS: u64 = 1;
 pub const BLOCK_HEIGHT_SANITY_LIMIT: u64 = 9000;
 
 /// Run the given hook command to obtain the last signing state
-pub fn run(config: &HookConfig) -> Result<Output, KmsError> {
+pub fn run(config: &HookConfig) -> Result<Output, Error> {
     let mut child = Command::new(&config.cmd[0])
         .args(&config.cmd[1..])
         .spawn()?;

--- a/src/chain/state/mod.rs
+++ b/src/chain/state/mod.rs
@@ -7,7 +7,7 @@ mod error;
 pub mod hook;
 
 pub use self::error::{StateError, StateErrorKind};
-use crate::error::{KmsError, KmsErrorKind::*};
+use crate::error::{Error, ErrorKind::*};
 use atomicwrites::{AtomicFile, OverwriteBehavior};
 use serde_json;
 use std::{
@@ -25,7 +25,7 @@ pub struct State {
 
 impl State {
     /// Load the state from the given path
-    pub fn load_state<P>(path: P) -> Result<State, KmsError>
+    pub fn load_state<P>(path: P) -> Result<State, Error>
     where
         P: AsRef<Path>,
     {

--- a/src/commands/help.rs
+++ b/src/commands/help.rs
@@ -1,19 +1,27 @@
 //! The `help` subcommand
 
-use abscissa::{Callable, Command};
+use abscissa::{Command, Runnable};
 
 use super::KmsCommand;
 
 /// The `help` subcommand
 #[derive(Debug, Default, Options)]
 pub struct HelpCommand {
+    /// Arguments to the `help` command
     #[options(free)]
     pub args: Vec<String>,
 }
 
-impl Callable for HelpCommand {
+impl Runnable for HelpCommand {
     /// Print help message
-    fn call(&self) {
-        KmsCommand::print_usage(self.args.as_slice());
+    fn run(&self) {
+        KmsCommand::print_usage(
+            &self
+                .args
+                .as_slice()
+                .iter()
+                .map(|arg| arg.as_ref())
+                .collect::<Vec<_>>(),
+        );
     }
 }

--- a/src/commands/keygen.rs
+++ b/src/commands/keygen.rs
@@ -1,5 +1,5 @@
 use crate::keyring::SecretKeyEncoding;
-use abscissa::Callable;
+use abscissa::Runnable;
 use signatory::{ed25519, Encode};
 use std::{env, process};
 
@@ -10,9 +10,9 @@ pub struct KeygenCommand {
     output_paths: Vec<String>,
 }
 
-impl Callable for KeygenCommand {
+impl Runnable for KeygenCommand {
     /// Generate an Ed25519 secret key for use with a software provider (i.e. ed25519-dalek)
-    fn call(&self) {
+    fn run(&self) {
         if self.output_paths.len() != 1 {
             eprintln!("Usage: {} keygen [PATH]", env::args().next().unwrap());
             process::exit(2);

--- a/src/commands/ledger/mod.rs
+++ b/src/commands/ledger/mod.rs
@@ -1,26 +1,19 @@
 //! Subcommands of the `tmkms` command-line application
 
-use crate::chain;
-use crate::config::KmsConfig;
-use abscissa::{Callable, GlobalConfig};
+use crate::{chain, prelude::*};
+use abscissa::{Command, Runnable};
 use std::process;
-use tendermint::amino_types::vote::{SignVoteRequest, Vote};
-use tendermint::amino_types::{SignableMsg, SignedMsgType};
+use tendermint::amino_types::{
+    vote::{SignVoteRequest, Vote},
+    SignableMsg, SignedMsgType,
+};
 
-#[derive(Debug, Options)]
+/// `ledger` subcommand
+#[derive(Command, Debug, Options, Runnable)]
 pub enum LedgerCommand {
+    /// Initialize HRS values
     #[options(help = "initialise the height/round/step")]
     Initialise(InitCommand),
-}
-
-impl_command!(LedgerCommand);
-
-impl Callable for LedgerCommand {
-    fn call(&self) {
-        match self {
-            LedgerCommand::Initialise(init) => init.call(),
-        }
-    }
 }
 
 impl LedgerCommand {
@@ -31,21 +24,25 @@ impl LedgerCommand {
     }
 }
 
+/// `ledger init` subcommand
 #[derive(Debug, Options)]
 pub struct InitCommand {
+    /// config file path
     #[options(short = "c", long = "config")]
     pub config: Option<String>,
 
+    /// block height
     #[options(short = "h", long = "height")]
     pub height: Option<i64>,
 
+    /// block round
     #[options(short = "r", long = "round")]
     pub round: Option<i64>,
 }
 
-impl Callable for InitCommand {
-    fn call(&self) {
-        let config = KmsConfig::get_global();
+impl Runnable for InitCommand {
+    fn run(&self) {
+        let config = app_config();
 
         chain::load_config(&config).unwrap_or_else(|e| {
             status_err!("error loading configuration: {}", e);

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -17,35 +17,38 @@ pub use self::{
     help::HelpCommand, keygen::KeygenCommand, start::StartCommand, version::VersionCommand,
 };
 use crate::config::{KmsConfig, CONFIG_ENV_VAR, CONFIG_FILE_NAME};
-use abscissa::{Callable, LoadConfig};
+use abscissa::{Command, Configurable, Runnable};
 use std::{env, path::PathBuf};
 
 /// Subcommands of the KMS command-line application
-#[derive(Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum KmsCommand {
+    /// `help` subcommand
     #[options(help = "show help for a command")]
     Help(HelpCommand),
 
+    /// `keygen` subcommand
     #[options(help = "generate a new software signing key")]
     Keygen(KeygenCommand),
 
+    /// `start` subcommand
     #[options(help = "start the KMS application")]
     Start(StartCommand),
 
+    /// `version` subcommand
     #[options(help = "display version information")]
     Version(VersionCommand),
 
+    /// `yubihsm` subcommand
     #[cfg(feature = "yubihsm")]
     #[options(help = "subcommands for YubiHSM2")]
     Yubihsm(YubihsmCommand),
 
+    /// `ledgertm` subcommand
     #[cfg(feature = "ledgertm")]
     #[options(help = "subcommands for Ledger")]
     Ledger(LedgerCommand),
 }
-
-// TODO: refactor abscissa internally so this is all part of the proc macro
-impl_command!(KmsCommand);
 
 impl KmsCommand {
     /// Are we configured for verbose logging?
@@ -59,7 +62,7 @@ impl KmsCommand {
     }
 }
 
-impl LoadConfig<KmsConfig> for KmsCommand {
+impl Configurable<KmsConfig> for KmsCommand {
     /// Get the path to the configuration file, either from selected subcommand
     /// or the default
     fn config_path(&self) -> Option<PathBuf> {
@@ -80,22 +83,5 @@ impl LoadConfig<KmsConfig> for KmsCommand {
         );
 
         Some(path)
-    }
-}
-
-// TODO: refactor abscissa internally so this is all part of the proc macro
-impl Callable for KmsCommand {
-    /// Call the given command chosen via the CLI
-    fn call(&self) {
-        match self {
-            KmsCommand::Help(help) => help.call(),
-            KmsCommand::Keygen(keygen) => keygen.call(),
-            KmsCommand::Start(run) => run.call(),
-            KmsCommand::Version(version) => version.call(),
-            #[cfg(feature = "yubihsm")]
-            KmsCommand::Yubihsm(yubihsm) => yubihsm.call(),
-            #[cfg(feature = "ledgertm")]
-            KmsCommand::Ledger(ledger) => ledger.call(),
-        }
     }
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,9 +1,4 @@
-use crate::{
-    chain,
-    client::Client,
-    config::{KmsConfig, ValidatorConfig},
-};
-use abscissa::{Callable, GlobalConfig};
+use crate::{chain, client::Client, config::ValidatorConfig, prelude::*};
 use std::{
     process,
     sync::{
@@ -34,16 +29,16 @@ impl Default for StartCommand {
     }
 }
 
-impl Callable for StartCommand {
+impl Runnable for StartCommand {
     /// Run the KMS
-    fn call(&self) {
+    fn run(&self) {
         info!(
             "{} {} starting up...",
             env!("CARGO_PKG_NAME"),
             env!("CARGO_PKG_VERSION")
         );
 
-        let config = KmsConfig::get_global();
+        let config = app_config();
 
         chain::load_config(&config).unwrap_or_else(|e| {
             status_err!("error loading configuration: {}", e);

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,15 +3,15 @@
 #![allow(clippy::never_loop)]
 
 use super::KmsCommand;
-use abscissa::{Callable, Command as CommandTrait};
+use abscissa::{Command as CommandTrait, Runnable};
 
 /// The `version` subcommand
 #[derive(Debug, Default, Options)]
 pub struct VersionCommand {}
 
-impl Callable for VersionCommand {
+impl Runnable for VersionCommand {
     /// Print version message
-    fn call(&self) {
+    fn run(&self) {
         KmsCommand::print_package_info();
     }
 }

--- a/src/commands/yubihsm/detect.rs
+++ b/src/commands/yubihsm/detect.rs
@@ -1,4 +1,4 @@
-use abscissa::Callable;
+use abscissa::Runnable;
 use std::process;
 use yubihsm::connector::usb::Devices;
 
@@ -14,9 +14,9 @@ pub struct DetectCommand {
     pub verbose: bool,
 }
 
-impl Callable for DetectCommand {
+impl Runnable for DetectCommand {
     /// Detect all YubiHSM2 devices connected via USB
-    fn call(&self) {
+    fn run(&self) {
         let devices = Devices::detect(Default::default()).unwrap_or_else(|e| {
             status_err!("couldn't detect USB devices: {}", e);
 

--- a/src/commands/yubihsm/help.rs
+++ b/src/commands/yubihsm/help.rs
@@ -1,16 +1,24 @@
 use super::YubihsmCommand;
-use abscissa::{Callable, Command};
+use abscissa::{Command, Runnable};
 
 /// The `yubihsm help` subcommand
 #[derive(Debug, Default, Options)]
 pub struct HelpCommand {
+    /// Arguments to the `yubihsm help` command
     #[options(free)]
     pub args: Vec<String>,
 }
 
-impl Callable for HelpCommand {
+impl Runnable for HelpCommand {
     /// Print help for the `yubihsm` subcommand
-    fn call(&self) {
-        YubihsmCommand::print_usage(self.args.as_slice());
+    fn run(&self) {
+        YubihsmCommand::print_usage(
+            &self
+                .args
+                .as_slice()
+                .iter()
+                .map(|arg| arg.as_ref())
+                .collect::<Vec<_>>(),
+        );
     }
 }

--- a/src/commands/yubihsm/keys/export.rs
+++ b/src/commands/yubihsm/keys/export.rs
@@ -1,10 +1,10 @@
 use super::*;
-use abscissa::Callable;
+use abscissa::{Command, Runnable};
 use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt, path::PathBuf, process};
 use subtle_encoding::base64;
 
 /// The `yubihsm keys export` subcommand: create encrypted backups of keys
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct ExportCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config")]
@@ -23,8 +23,8 @@ pub struct ExportCommand {
     pub path: PathBuf,
 }
 
-impl Callable for ExportCommand {
-    fn call(&self) {
+impl Runnable for ExportCommand {
+    fn run(&self) {
         let wrap_key_id = self.wrap_key_id.unwrap_or(DEFAULT_WRAP_KEY);
 
         let wrapped_bytes = crate::yubihsm::client()
@@ -70,5 +70,3 @@ impl Callable for ExportCommand {
         );
     }
 }
-
-impl_command!(ExportCommand);

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -1,5 +1,5 @@
 use super::*;
-use abscissa::Callable;
+use abscissa::{Command, Runnable};
 use chrono::{SecondsFormat, Utc};
 use std::{
     fs::OpenOptions,
@@ -12,7 +12,7 @@ use subtle_encoding::base64;
 use tendermint::PublicKey;
 
 /// The `yubihsm keys generate` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct GenerateCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config")]
@@ -47,9 +47,9 @@ pub struct GenerateCommand {
     key_ids: Vec<u16>,
 }
 
-impl Callable for GenerateCommand {
+impl Runnable for GenerateCommand {
     /// Generate an Ed25519 signing key inside a YubiHSM2 device
-    fn call(&self) {
+    fn run(&self) {
         if self.key_ids.len() != 1 {
             status_err!(
                 "expected exactly 1 key ID to generate, got {}",
@@ -116,7 +116,7 @@ impl Callable for GenerateCommand {
             None => public_key.to_hex(),
         };
 
-        status_ok!("Generated", "key #{}: {}", key_id, public_key_string);
+        status_ok!("Generated", "key 0x{:04x}: {}", key_id, public_key_string);
 
         if let Some(ref backup_file) = self.backup_file {
             create_encrypted_backup(
@@ -128,9 +128,6 @@ impl Callable for GenerateCommand {
         }
     }
 }
-
-// TODO: custom derive in abscissa
-impl_command!(GenerateCommand);
 
 /// Create an encrypted backup of this key under the given wrap key ID
 // TODO(tarcieri): unify this with the similar code in export?

--- a/src/commands/yubihsm/keys/help.rs
+++ b/src/commands/yubihsm/keys/help.rs
@@ -1,5 +1,5 @@
 use super::KeysCommand;
-use abscissa::{Callable, Command};
+use abscissa::{Command, Runnable};
 
 /// The `yubihsm keys help` subcommand
 #[derive(Debug, Default, Options)]
@@ -8,9 +8,16 @@ pub struct HelpCommand {
     pub args: Vec<String>,
 }
 
-impl Callable for HelpCommand {
+impl Runnable for HelpCommand {
     /// Print help for the `yubihsm` subcommand
-    fn call(&self) {
-        KeysCommand::print_usage(self.args.as_slice());
+    fn run(&self) {
+        KeysCommand::print_usage(
+            &self
+                .args
+                .as_slice()
+                .iter()
+                .map(|arg| arg.as_ref())
+                .collect::<Vec<_>>(),
+        );
     }
 }

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -1,5 +1,7 @@
+//! Import keys
+
 use super::*;
-use abscissa::Callable;
+use abscissa::{Command, Runnable};
 use signatory::ed25519;
 use std::{fs, path::PathBuf, process};
 use subtle_encoding::base64;
@@ -7,7 +9,7 @@ use tendermint::PublicKey;
 use yubihsm::object;
 
 /// The `yubihsm keys import` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct ImportCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config")]
@@ -34,8 +36,8 @@ pub struct ImportCommand {
     pub path: PathBuf,
 }
 
-impl Callable for ImportCommand {
-    fn call(&self) {
+impl Runnable for ImportCommand {
+    fn run(&self) {
         let contents = fs::read_to_string(&self.path).unwrap_or_else(|e| {
             status_err!("couldn't import file {}: {}", self.path.display(), e);
             process::exit(1);
@@ -176,8 +178,8 @@ impl ImportCommand {
             process::exit(1);
         });
 
-        let seed = ed25519::Seed::from_keypair(&key_pair).unwrap_or_else(|e| {
-            status_err!("invalid key in validator config: {}", e);
+        let seed = ed25519::Seed::from_keypair(&key_pair).unwrap_or_else(|| {
+            status_err!("error parsing ed25519 seed");
             process::exit(1);
         });
 
@@ -201,5 +203,3 @@ impl ImportCommand {
         status_ok!("Imported", "key 0x{:04x}", key_id);
     }
 }
-
-impl_command!(ImportCommand);

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,18 +1,20 @@
-use abscissa::Callable;
+//! List keys
+
+use abscissa::{Command, Runnable};
 use std::process;
 use tendermint::PublicKey;
 
 /// The `yubihsm keys list` subcommand
-#[derive(Debug, Default, Options)]
+#[derive(Command, Debug, Default, Options)]
 pub struct ListCommand {
     /// Path to configuration file
     #[options(short = "c", long = "config")]
     pub config: Option<String>,
 }
 
-impl Callable for ListCommand {
+impl Runnable for ListCommand {
     /// List all suitable Ed25519 keys in the HSM
-    fn call(&self) {
+    fn run(&self) {
         let hsm = crate::yubihsm::client();
 
         let serial_number = hsm
@@ -68,6 +70,3 @@ impl Callable for ListCommand {
         }
     }
 }
-
-// TODO: custom derive in abscissa
-impl_command!(ListCommand);

--- a/src/commands/yubihsm/keys/mod.rs
+++ b/src/commands/yubihsm/keys/mod.rs
@@ -8,7 +8,7 @@ use self::{
     export::ExportCommand, generate::GenerateCommand, help::HelpCommand, import::ImportCommand,
     list::ListCommand,
 };
-use abscissa::Callable;
+use abscissa::{Command, Runnable};
 
 /// Default key type to generate
 pub const DEFAULT_KEY_TYPE: &str = "ed25519";
@@ -23,7 +23,7 @@ pub const DEFAULT_CAPABILITIES: yubihsm::Capability = yubihsm::Capability::SIGN_
 pub const DEFAULT_WRAP_KEY: yubihsm::object::Id = 1;
 
 /// The `yubihsm keys` subcommand
-#[derive(Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum KeysCommand {
     #[options(help = "export an encrypted backup of a signing key inside the HSM device")]
     Export(ExportCommand),
@@ -53,20 +53,3 @@ impl KeysCommand {
         }
     }
 }
-
-// TODO: refactor abscissa internally so this is all part of the proc macro
-impl Callable for KeysCommand {
-    /// Call the given command chosen via the CLI
-    fn call(&self) {
-        match self {
-            KeysCommand::Export(export) => export.call(),
-            KeysCommand::Generate(generate) => generate.call(),
-            KeysCommand::Help(help) => help.call(),
-            KeysCommand::Import(import) => import.call(),
-            KeysCommand::List(list) => list.call(),
-        }
-    }
-}
-
-// TODO: custom derive in abscissa
-impl_command!(KeysCommand);

--- a/src/commands/yubihsm/mod.rs
+++ b/src/commands/yubihsm/mod.rs
@@ -1,7 +1,5 @@
 //! The KMS `yubihsm` subcommand
 
-use abscissa::Callable;
-
 mod detect;
 mod help;
 mod keys;
@@ -12,41 +10,30 @@ pub use self::{
     detect::DetectCommand, help::HelpCommand, keys::KeysCommand, setup::SetupCommand,
     test::TestCommand,
 };
+use abscissa::{Command, Runnable};
 
 /// The `yubihsm` subcommand
-#[derive(Debug, Options)]
+#[derive(Command, Debug, Options, Runnable)]
 pub enum YubihsmCommand {
+    /// Detected connected YubiHSM2 devices
     #[options(help = "detect all YubiHSM2 devices connected via USB")]
     Detect(DetectCommand),
 
+    /// Show help for the `yubihsm` subcommand
     #[options(help = "show help for the 'yubihsm' subcommand")]
     Help(HelpCommand),
 
+    /// Key management subcommands
     #[options(help = "key management subcommands")]
     Keys(KeysCommand),
 
+    /// Perform initial YubiHSM2 device setup
     #[options(help = "initial device setup and configuration")]
     Setup(SetupCommand),
 
+    /// Perform a signing test
     #[options(help = "perform a signing test")]
     Test(TestCommand),
-}
-
-// TODO: custom derive in abscissa
-impl_command!(YubihsmCommand);
-
-// TODO: refactor abscissa internally so this is all part of the proc macro
-impl Callable for YubihsmCommand {
-    /// Call the given command chosen via the CLI
-    fn call(&self) {
-        match self {
-            YubihsmCommand::Detect(detect) => detect.call(),
-            YubihsmCommand::Help(help) => help.call(),
-            YubihsmCommand::Keys(keys) => keys.call(),
-            YubihsmCommand::Setup(setup) => setup.call(),
-            YubihsmCommand::Test(test) => test.call(),
-        }
-    }
 }
 
 impl YubihsmCommand {

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -1,4 +1,4 @@
-use abscissa::Callable;
+use abscissa::Runnable;
 use bip39::Mnemonic;
 use chrono::{SecondsFormat, Utc};
 use hkdf::Hkdf;
@@ -63,9 +63,9 @@ pub struct SetupCommand {
     pub write_report: Option<PathBuf>,
 }
 
-impl Callable for SetupCommand {
+impl Runnable for SetupCommand {
     /// Perform initial YubiHSM dervice provisioning
-    fn call(&self) {
+    fn run(&self) {
         let hsm_connector = crate::yubihsm::connector();
         let hsm_serial_number = get_hsm_client(&hsm_connector)
             .device_info()

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,4 +1,4 @@
-use abscissa::Callable;
+use abscissa::Runnable;
 use std::{
     thread,
     time::{Duration, Instant},
@@ -23,9 +23,9 @@ pub struct TestCommand {
     key_id: u16,
 }
 
-impl Callable for TestCommand {
+impl Runnable for TestCommand {
     /// Perform a signing test using the current HSM configuration
-    fn call(&self) {
+    fn run(&self) {
         let hsm = crate::yubihsm::client();
 
         loop {

--- a/src/config/chain/hook.rs
+++ b/src/config/chain/hook.rs
@@ -1,7 +1,8 @@
+use serde::Deserialize;
 use std::ffi::OsString;
 
 /// Configuration for a particular hook to invoke
-#[derive(Clone, Default, Deserialize, Debug)]
+#[derive(Default, Deserialize, Debug)]
 pub struct HookConfig {
     /// Command (with arguments) to invoke
     pub cmd: Vec<OsString>,

--- a/src/config/chain/mod.rs
+++ b/src/config/chain/mod.rs
@@ -4,10 +4,11 @@ mod hook;
 
 pub use self::hook::HookConfig;
 use crate::{chain, keyring};
+use serde::Deserialize;
 use std::path::PathBuf;
 
 /// Chain configuration
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct ChainConfig {
     /// Chain ID of this Tendermint network/chain
     pub id: chain::Id,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,8 @@ pub mod validator;
 
 pub use self::validator::*;
 use self::{chain::ChainConfig, provider::ProviderConfig};
+use abscissa::Config;
+use serde::Deserialize;
 
 /// Environment variable containing path to config file
 pub const CONFIG_ENV_VAR: &str = "TMKMS_CONFIG_FILE";
@@ -14,7 +16,7 @@ pub const CONFIG_ENV_VAR: &str = "TMKMS_CONFIG_FILE";
 pub const CONFIG_FILE_NAME: &str = "tmkms.toml";
 
 /// KMS configuration (i.e. TOML file parsed with serde)
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Config, Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct KmsConfig {
     /// Chains the KMS is providing key management service for
@@ -28,7 +30,3 @@ pub struct KmsConfig {
     /// Cryptographic signature provider configuration
     pub providers: ProviderConfig,
 }
-
-// Impl the `abscissa::GlobalConfig` trait, storing the configuration in the
-// `GLOBAL_CONFIG` static value
-impl_global_config!(KmsConfig, GLOBAL_CONFIG);

--- a/src/config/provider/ledgertm.rs
+++ b/src/config/provider/ledgertm.rs
@@ -1,9 +1,10 @@
 //! Configuration for Ledger Tendermint signer
 
 use crate::chain;
+use serde::Deserialize;
 
 /// Ledger Tendermint signer configuration
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct LedgerTendermintConfig {
     /// Chains this signing key is authorized to be used from
     pub chain_ids: Vec<chain::Id>,

--- a/src/config/provider/mod.rs
+++ b/src/config/provider/mod.rs
@@ -1,3 +1,5 @@
+//! Cryptographic service providers: signing backends
+
 #[cfg(feature = "ledgertm")]
 pub mod ledgertm;
 #[cfg(feature = "softsign")]
@@ -11,9 +13,10 @@ use self::ledgertm::LedgerTendermintConfig;
 use self::softsign::SoftSignConfig;
 #[cfg(feature = "yubihsm")]
 use self::yubihsm::YubihsmConfig;
+use serde::Deserialize;
 
 /// Provider configuration
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct ProviderConfig {
     /// Software-backed signer
     #[cfg(feature = "softsign")]

--- a/src/config/provider/softsign.rs
+++ b/src/config/provider/softsign.rs
@@ -1,10 +1,11 @@
 //! Configuration for software-backed signer (using ed25519-dalek)
 
 use crate::chain;
+use serde::Deserialize;
 use std::path::{Path, PathBuf};
 
 /// Software signer configuration
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct SoftSignConfig {
     /// Chains this signing key is authorized to be used from
     pub chain_ids: Vec<chain::Id>,
@@ -15,7 +16,7 @@ pub struct SoftSignConfig {
 }
 
 /// Software-backed private key (stored in a file)
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct SoftPrivateKey(PathBuf);
 
 impl SoftPrivateKey {

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -1,3 +1,6 @@
+//! Validator configuration
+
+use serde::Deserialize;
 use std::path::PathBuf;
 use tendermint::{chain, net};
 

--- a/src/keyring/ed25519/mod.rs
+++ b/src/keyring/ed25519/mod.rs
@@ -1,3 +1,5 @@
+//! Ed25519 signing keys
+
 pub use signatory::ed25519::{PublicKey, Seed, Signature, PUBLIC_KEY_SIZE};
 
 #[cfg(feature = "ledgertm")]

--- a/src/keyring/ed25519/softsign.rs
+++ b/src/keyring/ed25519/softsign.rs
@@ -6,7 +6,7 @@ use super::Signer;
 use crate::{
     chain,
     config::provider::softsign::SoftSignConfig,
-    error::{KmsError, KmsErrorKind::*},
+    error::{Error, ErrorKind::*},
     keyring::SigningProvider,
 };
 use signatory::{ed25519, encoding::Decode, PublicKeyed};
@@ -15,10 +15,7 @@ use subtle_encoding::IDENTITY;
 use tendermint::TendermintKey;
 
 /// Create software-backed Ed25519 signer objects from the given configuration
-pub fn init(
-    chain_registry: &mut chain::Registry,
-    configs: &[SoftSignConfig],
-) -> Result<(), KmsError> {
+pub fn init(chain_registry: &mut chain::Registry, configs: &[SoftSignConfig]) -> Result<(), Error> {
     for config in configs {
         let seed =
             ed25519::Seed::decode_from_file(config.path.as_path(), IDENTITY).map_err(|e| {
@@ -31,8 +28,15 @@ pub fn init(
             })?;
 
         let provider = Ed25519Signer::from(&seed);
+
         // TODO(tarcieri): support for adding account keys into keyrings
-        let public_key = TendermintKey::ConsensusKey(provider.public_key()?.into());
+        let public_key = TendermintKey::ConsensusKey(
+            provider
+                .public_key()
+                .map_err(|_| Error::from(InvalidKey))?
+                .into(),
+        );
+
         let signer = Signer::new(SigningProvider::SoftSign, public_key, Box::new(provider));
 
         for chain_id in &config.chain_ids {

--- a/src/keyring/format.rs
+++ b/src/keyring/format.rs
@@ -1,5 +1,6 @@
 //! Chain-specific key configuration
 
+use serde::Deserialize;
 use tendermint::TendermintKey;
 
 /// Options for how keys for this chain are represented

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,27 +18,20 @@ extern crate prost_amino as prost;
 #[macro_use]
 extern crate abscissa;
 #[macro_use]
-extern crate abscissa_derive;
-#[macro_use]
-extern crate failure_derive;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate serde_derive;
+extern crate log;
 
-#[macro_use]
-mod error;
-
-mod application;
-mod chain;
-mod client;
-mod commands;
-mod config;
-mod keyring;
-mod rpc;
-mod session;
-mod unix_connection;
+pub mod application;
+pub mod chain;
+pub mod client;
+pub mod commands;
+pub mod config;
+pub mod error;
+pub mod keyring;
+pub mod prelude;
+pub mod rpc;
+pub mod session;
+pub mod unix_connection;
 #[cfg(feature = "yubihsm")]
-mod yubihsm;
+pub mod yubihsm;
 
 pub use crate::{application::KmsApplication, unix_connection::UnixConnection};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,11 @@
+//! Application-local prelude: conveniently import types/functions/macros
+//! which are generally useful and should be available everywhere.
+
+/// Application state accessors
+pub use crate::application::{app_config, app_reader, app_writer};
+
+/// Commonly used Abscissa traits
+pub use abscissa::{Application, Command, Runnable};
+
+/// Logging macros
+pub use log::{debug, error, info, log, log_enabled, trace, warn};

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,17 +1,22 @@
 //! Remote Procedure Calls
 
+// TODO: docs for everything
+#![allow(missing_docs)]
+
 use crate::{
     prost::encoding::{decode_varint, encoded_len_varint},
     prost::Message,
 };
 
 use bytes::IntoBuf;
+use lazy_static::lazy_static;
 use sha2::{Digest, Sha256};
 use std::io::Cursor;
 use std::io::{self, Read};
 use std::io::{Error, ErrorKind};
 use tendermint::amino_types::*;
 
+/// Maximum size of an RPC message
 pub const MAX_MSG_LEN: usize = 1024;
 
 /// Requests to the KMS

--- a/src/unix_connection.rs
+++ b/src/unix_connection.rs
@@ -1,3 +1,5 @@
+//! Unix domain socket connection
+
 use std::io;
 use std::marker::{Send, Sync};
 

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -41,15 +41,15 @@ rand_os = { version = "0.1", optional = true }
 ring = { version = "0.14", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
-signatory = { version = "0.11.2", features = ["ed25519", "ecdsa"] }
-signatory-dalek = { version = "0.11", optional = true }
+signatory = { version = "0.12", features = ["ed25519", "ecdsa"] }
+signatory-dalek = { version = "0.12", optional = true }
 sha2 = { version = "0.8", default-features = false }
 subtle = "2"
 subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
-tai64 = { version = "1", optional = true, features = ["chrono"] }
+tai64 = { version = "2", optional = true, features = ["chrono"] }
 uuid = { version = "0.7", optional = true, default-features = false }
 x25519-dalek = { version = "0.5", optional = true, default-features = false, features = ["u64_backend"] }
-zeroize = { version = "0.6", optional = true }
+zeroize = { version = "0.9", optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/tendermint-rs/src/error.rs
+++ b/tendermint-rs/src/error.rs
@@ -77,13 +77,7 @@ impl From<subtle_encoding::Error> for Error {
 }
 
 impl From<signatory::Error> for Error {
-    fn from(other: signatory::Error) -> Self {
-        match other.kind() {
-            signatory::ErrorKind::Io => Error::Io,
-            signatory::ErrorKind::KeyInvalid => Error::InvalidKey,
-            signatory::ErrorKind::ParseError => Error::Parse,
-            signatory::ErrorKind::ProviderError => Error::Crypto,
-            signatory::ErrorKind::SignatureInvalid => Error::SignatureInvalid,
-        }
+    fn from(_other: signatory::Error) -> Self {
+        Error::Crypto
     }
 }

--- a/tendermint-rs/src/secret_connection/public_key.rs
+++ b/tendermint-rs/src/secret_connection/public_key.rs
@@ -14,7 +14,9 @@ pub enum PublicKey {
 impl PublicKey {
     /// From raw Ed25519 public key bytes
     pub fn from_raw_ed25519(bytes: &[u8]) -> Result<PublicKey, Error> {
-        Ok(PublicKey::Ed25519(ed25519::PublicKey::from_bytes(bytes)?))
+        Ok(PublicKey::Ed25519(
+            ed25519::PublicKey::from_bytes(bytes).ok_or_else(|| Error::Crypto)?,
+        ))
     }
 
     /// Get Ed25519 public key

--- a/tests/cli/yubihsm/keys/generate.rs
+++ b/tests/cli/yubihsm/keys/generate.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `yubihsm keys generate` subcommand
 
 use crate::cli;
+use std::str;
 
 #[test]
 fn keys_generate_command_test() {
@@ -10,15 +11,11 @@ fn keys_generate_command_test() {
     #[cfg(feature = "yubihsm-mock")]
     args.extend_from_slice(&["-c", super::KMS_CONFIG_PATH]);
 
-    let out = cli::run_successfully(args.as_slice());
+    let cmd_out = cli::run_successfully(args.as_slice());
+    assert_eq!(true, cmd_out.status.success());
+    assert_eq!(true, cmd_out.stderr.is_empty());
 
-    assert_eq!(true, out.status.success());
-    assert_eq!(true, out.stderr.is_empty());
-    assert_eq!(
-        true,
-        String::from_utf8(out.stdout)
-            .unwrap()
-            .trim()
-            .starts_with("Generated key #1:")
-    );
+    let stdout = str::from_utf8(&cmd_out.stdout).unwrap().trim().to_owned();
+    assert!(stdout.contains("Generated"));
+    assert!(stdout.contains("key 0x0001"));
 }

--- a/tests/cli/yubihsm/keys/import.rs
+++ b/tests/cli/yubihsm/keys/import.rs
@@ -20,5 +20,5 @@ fn keys_import_priv_validator_test() {
     assert_eq!(true, out.stderr.is_empty());
 
     let message = str::from_utf8(&out.stdout).unwrap().trim().to_owned();
-    assert_eq!(true, message.starts_with("Imported key 0x0001"));
+    assert_eq!(true, message.contains("key 0x0001"));
 }

--- a/tests/cli/yubihsm/keys/list.rs
+++ b/tests/cli/yubihsm/keys/list.rs
@@ -1,6 +1,7 @@
 //! Integration tests for the `yubihsm keys list` subcommand
 
 use crate::cli;
+use std::str;
 
 #[test]
 fn keys_command_test() {
@@ -14,11 +15,7 @@ fn keys_command_test() {
 
     assert_eq!(true, out.status.success());
     assert_eq!(true, out.stdout.is_empty());
-    assert_eq!(
-        true,
-        String::from_utf8(out.stderr)
-            .unwrap()
-            .trim()
-            .starts_with("error: no keys in this YubiHSM")
-    );
+
+    let stderr = str::from_utf8(&out.stderr).unwrap().trim().to_owned();
+    assert!(stderr.contains("no keys in this YubiHSM"));
 }


### PR DESCRIPTION
I'm preparing another release of Abscissa, which provides the application boilerplate / framework used by Tendermint KMS:

https://github.com/iqlusioninc/abscissa

This commit contains what is hopefully the minimum set of changes required to upgrade to the new version.

Notably it removes all TODOs about boilerplate code that could potentially be replaced by custom derive, as `abscissa_derive` now provides that functionality.

It also incorporates global application state, and the application as the owner of the configuration.