### PR TITLE
Bump CI build image version to 2019-06-05-v0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@ version: 2
 jobs:
   build:
     docker:
-    - image: tendermint/kms:build-2019-03-21-v0 # bump cache keys when modifying this
+    - image: tendermint/kms:build-2019-06-05-v0 # bump cache keys when modifying this
     steps:
     - checkout
     - restore_cache:
-        key: cache-2019-03-21-v0 # bump save_cache key below too
+        key: cache-2019-06-05-v0 # bump save_cache key below too
     - run:
         name: rustfmt
         command: |
@@ -52,7 +52,7 @@ jobs:
           cargo build --features=softsign
           TMKMS_BIN=./target/debug/tmkms sh tests/support/run-harness-tests.sh
     - save_cache:
-        key: cache-2019-03-21-v0 # bump restore_cache key above too
+        key: cache-2019-06-05-v0 # bump restore_cache key above too
         paths:
         - "~/.cargo"
         - "./target"


### PR DESCRIPTION
Updates `tm-signer-harness` to the one from Tendermint v0.31.7, and updates the KMS build image to the latest stable version of Rust (1.35.0) using KMS v0.6.0-alpha1.