### PR TITLE
tendermint-rs: Add tests for `/block_results` RPC endpoint

### DIFF
--- a/tendermint-rs/src/abci/gas.rs
+++ b/tendermint-rs/src/abci/gas.rs
@@ -16,6 +16,13 @@ use std::{
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Gas(u64);
 
+impl Gas {
+    /// Get the inner integer value
+    pub fn value(self) -> u64 {
+        self.0
+    }
+}
+
 impl From<u64> for Gas {
     fn from(amount: u64) -> Gas {
         Gas(amount)

--- a/tendermint-rs/tests/support/rpc/block_results.json
+++ b/tendermint-rs/tests/support/rpc/block_results.json
@@ -1,0 +1,94 @@
+{
+  "jsonrpc": "2.0",
+  "id": "",
+  "result": {
+    "height": "1814",
+    "results": {
+      "DeliverTx": [
+        {
+          "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
+          "gasWanted": "200000",
+          "gasUsed": "105662",
+          "tags": [
+            {
+              "key": "YWN0aW9u",
+              "value": "ZGVsZWdhdGU="
+            },
+            {
+              "key": "ZGVsZWdhdG9y",
+              "value": "Y29zbW9zMW53eWV5cXVkenJ1NWw2NGU4M2RubXE3OXE0c3Rxejdmd2w1djVh"
+            },
+            {
+              "key": "ZGVzdGluYXRpb24tdmFsaWRhdG9y",
+              "value": "Y29zbW9zdmFsb3BlcjFlaDVtd3UwNDRnZDVudGtrYzJ4Z2ZnODI0N21nYzU2Zno0c2RnMw=="
+            }
+          ]
+        },
+        {
+          "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
+          "gasWanted": "99164",
+          "gasUsed": "99164",
+          "tags": [
+            {
+              "key": "YWN0aW9u",
+              "value": "ZGVsZWdhdGU="
+            },
+            {
+              "key": "ZGVsZWdhdG9y",
+              "value": "Y29zbW9zMTBhN2V2eXlkY2s0Mm5odGE5M3RubXY3eXU0aGFxenQ5NHh5dTU0"
+            },
+            {
+              "key": "ZGVzdGluYXRpb24tdmFsaWRhdG9y",
+              "value": "Y29zbW9zdmFsb3BlcjF1cnRweHdmdXU4azU3YXF0MGg1emhzdm1qdDRtMm1tZHIwanV6Zw=="
+            }
+          ]
+        },
+        {
+          "log": "[{\"msg_index\":\"0\",\"success\":true,\"log\":\"\"}]",
+          "gasWanted": "200000",
+          "gasUsed": "106515",
+          "tags": [
+            {
+              "key": "YWN0aW9u",
+              "value": "ZGVsZWdhdGU="
+            },
+            {
+              "key": "ZGVsZWdhdG9y",
+              "value": "Y29zbW9zMXFtcmNqenNrZ3Rsd21mczlwcWRyZnBtcDVsNWM4cDVyM3kzZTl0"
+            },
+            {
+              "key": "ZGVzdGluYXRpb24tdmFsaWRhdG9y",
+              "value": "Y29zbW9zdmFsb3BlcjFzeHg5bXN6dmUwZ2FlZHo1bGQ3cWRramtmdjh6OTkyYXg2OWswOA=="
+            }
+          ]
+        }
+      ],
+      "EndBlock": {
+        "validator_updates": [
+          {
+            "pub_key": {
+              "type": "ed25519",
+              "data": "lObsqlAjmPsnBfBE+orb8vBbKrH2G5VskSUlAq/YcXc="
+            },
+            "power": "1233243"
+          },
+          {
+            "pub_key": {
+              "type": "ed25519",
+              "data": "PflSgb+lC1GI22wc6N/54cNzD7KSYQyCWR5LuQxjYVY="
+            },
+            "power": "1194975"
+          },
+          {
+            "pub_key": {
+              "type": "ed25519",
+              "data": "AmPqEmF5YNmlv2vu8lEcDeQ3hyR+lymnqx2VixdMEzA="
+            },
+            "power": "12681"
+          }
+        ]
+      },
+      "BeginBlock": {}
+    }
+  }
+}


### PR DESCRIPTION
Previously there was only a live integration test.

This tests against a vendored RPC result for cosmoshub-1, and does a number of assertions on how the data is parsed.

It also simplifies the API somewhat through the addition of some custom parsers that eliminate superfluous `Option` types (e.g. where an empty `Vec` would suffice).