### PR TITLE
tendermint-rs v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1282,7 +1282,7 @@ dependencies = [
  "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.7.0",
+ "tendermint 0.8.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.25.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,11 +45,15 @@ signatory-secp256k1 = "0.12"
 signatory-ledger-tm = { version = "0.12", optional = true }
 subtle = "2"
 subtle-encoding = { version = "0.3", features = ["bech32-preview"] }
-tendermint = { version = "0.7", path = "tendermint-rs", features = ["amino-types", "secret-connection"] }
 tiny-bip39 = "0.6"
 wait-timeout = "0.2"
 yubihsm = { version = "0.25", features = ["setup", "usb"], optional = true }
 zeroize = "0.9"
+
+[dependencies.tendermint]
+version = "0.8"
+path = "tendermint-rs"
+features = ["amino-types", "secret-connection"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,10 @@
+## [0.8.0] (2019-06-20)
+
+This release is compatible with [tendermint v0.31]
+
+- `/block_results` RPC endpoint and related types ([#267], [#268])
+- Upgrade to Signatory v0.12 ([#259])
+
 ## [0.7.0] (2019-04-24)
 
 This release is compatible with [tendermint v0.31]
@@ -66,6 +73,10 @@ This release is compatible with [tendermint v0.28]
 
 - Initial release
 
+[0.8.0]: https://github.com/tendermint/kms/pull/269
+[#268]: https://github.com/tendermint/kms/pull/268
+[#267]: https://github.com/tendermint/kms/pull/267
+[#259]: https://github.com/tendermint/kms/pull/259
 [0.7.0]: https://github.com/tendermint/kms/pull/247
 [#243]: https://github.com/tendermint/kms/pull/243
 [#235]: https://github.com/tendermint/kms/pull/235

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.7.0" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.8.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -15,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.7.0"
+    html_root_url = "https://docs.rs/tendermint/0.8.0"
 )]
 
 #[cfg(feature = "amino-types")]

--- a/tendermint-rs/src/validator.rs
+++ b/tendermint-rs/src/validator.rs
@@ -74,8 +74,7 @@ pub struct Update {
 /// implemented in `tendermint::PublicKey`.
 ///
 /// This is an internal thunk type to parse the `validator_updates` format and
-/// then convert to `tendermint::PublicKey`.
-/// Public keys allowed in Tendermint protocols
+/// then convert to `tendermint::PublicKey` in `deserialize_public_key` below.
 #[cfg(feature = "rpc")]
 #[derive(Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]


### PR DESCRIPTION
This release is compatible with [tendermint v0.31]

- `/block_results` RPC endpoint and related types (#267, #268)
- Upgrade to Signatory v0.12 (#259)

[tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0310