### PR TITLE
Log all signature events at INFO level

### DIFF
--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -20,6 +20,7 @@ use tendermint::amino_types::*;
 pub const MAX_MSG_LEN: usize = 1024;
 
 /// Requests to the KMS
+#[derive(Debug)]
 pub enum Request {
     /// Sign the given message
     SignProposal(SignProposalRequest),
@@ -31,6 +32,7 @@ pub enum Request {
 }
 
 /// Responses from the KMS
+#[derive(Debug)]
 pub enum Response {
     /// Signature response
     SignedVote(SignedVoteResponse),

--- a/tendermint-rs/src/amino_types/proposal.rs
+++ b/tendermint-rs/src/amino_types/proposal.rs
@@ -159,6 +159,10 @@ impl SignableMsg for SignProposalRequest {
     fn height(&self) -> Option<i64> {
         self.proposal.as_ref().map(|proposal| proposal.height)
     }
+
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        Some(SignedMsgType::Proposal)
+    }
 }
 
 impl ConsensusMessage for Proposal {

--- a/tendermint-rs/src/amino_types/signature.rs
+++ b/tendermint-rs/src/amino_types/signature.rs
@@ -18,6 +18,7 @@ pub trait SignableMsg {
     fn validate(&self) -> Result<(), ValidationError>;
     fn consensus_state(&self) -> Option<consensus::State>;
     fn height(&self) -> Option<i64>;
+    fn msg_type(&self) -> Option<SignedMsgType>;
 }
 
 /// Signed message types. This follows:

--- a/tendermint-rs/src/amino_types/vote.rs
+++ b/tendermint-rs/src/amino_types/vote.rs
@@ -38,9 +38,14 @@ pub struct Vote {
 }
 
 impl Vote {
-    fn is_valid_vote_type(&self) -> bool {
-        self.vote_type == SignedMsgType::PreVote.to_u32()
-            || self.vote_type == SignedMsgType::PreCommit.to_u32()
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        if self.vote_type == SignedMsgType::PreVote.to_u32() {
+            Some(SignedMsgType::PreVote)
+        } else if self.vote_type == SignedMsgType::PreCommit.to_u32() {
+            Some(SignedMsgType::PreCommit)
+        } else {
+            None
+        }
     }
 }
 
@@ -179,11 +184,14 @@ impl SignableMsg for SignVoteRequest {
     fn height(&self) -> Option<i64> {
         self.vote.as_ref().map(|vote| vote.height)
     }
+    fn msg_type(&self) -> Option<SignedMsgType> {
+        self.vote.as_ref().and_then(|vote| vote.msg_type())
+    }
 }
 
 impl ConsensusMessage for Vote {
     fn validate_basic(&self) -> Result<(), ValidationError> {
-        if !self.is_valid_vote_type() {
+        if self.msg_type().is_none() {
             return Err(InvalidMessageType.into());
         }
         if self.height < 0 {


### PR DESCRIPTION
...and improve logging at the debug level in general.

Previously the KMS logged no information about what it signed at the default loglevel (INFO). To get that information, you had to log at the DEBUG level.

This adds short loglines at the INFO level. They contain the chain ID, signed message type (proposal, prevote, precommit), and block height.

Additionally, at the debug level it now prints debug messages containing the complete incoming request and response.