### PR TITLE
Send RemoteSignerError response on double sign (closes #249)

### DIFF
--- a/src/chain/state/error.rs
+++ b/src/chain/state/error.rs
@@ -29,6 +29,13 @@ pub enum StateErrorKind {
     SyncError,
 }
 
+impl StateError {
+    /// Get the kind of error
+    pub fn kind(&self) -> StateErrorKind {
+        *self.0.kind()
+    }
+}
+
 impl From<Error<StateErrorKind>> for StateError {
     fn from(other: Error<StateErrorKind>) -> Self {
         StateError(other)

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -42,8 +42,7 @@ pub enum Response {
 }
 
 pub trait TendermintRequest: SignableMsg {
-    // TODO(ismail): this should take an error as an argument:
-    fn build_response(self) -> Response;
+    fn build_response(self, error: Option<RemoteError>) -> Response;
 }
 
 fn compute_prefix(name: &str) -> (Vec<u8>) {
@@ -113,19 +112,37 @@ impl Request {
 }
 
 impl TendermintRequest for SignVoteRequest {
-    fn build_response(self) -> Response {
-        Response::SignedVote(SignedVoteResponse {
-            vote: self.vote,
-            err: None,
-        })
+    fn build_response(self, error: Option<RemoteError>) -> Response {
+        let response = if let Some(e) = error {
+            SignedVoteResponse {
+                vote: None,
+                err: Some(e),
+            }
+        } else {
+            SignedVoteResponse {
+                vote: self.vote,
+                err: None,
+            }
+        };
+
+        Response::SignedVote(response)
     }
 }
 
 impl TendermintRequest for SignProposalRequest {
-    fn build_response(self) -> Response {
-        Response::SignedProposal(SignedProposalResponse {
-            proposal: self.proposal,
-            err: None,
-        })
+    fn build_response(self, error: Option<RemoteError>) -> Response {
+        let response = if let Some(e) = error {
+            SignedProposalResponse {
+                proposal: None,
+                err: Some(e),
+            }
+        } else {
+            SignedProposalResponse {
+                proposal: self.proposal,
+                err: None,
+            }
+        };
+
+        Response::SignedProposal(response)
     }
 }

--- a/tendermint-rs/src/amino_types/remote_error.rs
+++ b/tendermint-rs/src/amino_types/remote_error.rs
@@ -5,3 +5,26 @@ pub struct RemoteError {
     #[prost(string, tag = "2")]
     pub description: String,
 }
+
+/// Error codes for remote signer failures
+// TODO(tarcieri): add these to Tendermint. See corresponding TODO here:
+// <https://github.com/tendermint/tendermint/blob/master/privval/errors.go>
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(i32)]
+pub enum RemoteErrorCode {
+    /// Generic error code useful when the others don't apply
+    RemoteSignerError = 1,
+
+    /// Double signing detected
+    DoubleSignError = 2,
+}
+
+impl RemoteError {
+    /// Create a new double signing error with the given message
+    pub fn double_sign(height: i64) -> Self {
+        RemoteError {
+            code: RemoteErrorCode::DoubleSignError as i32,
+            description: format!("double signing requested at height: {}", height),
+        }
+    }
+}


### PR DESCRIPTION
Previously double signing would abort the connection.

However, there is a semi-valid use case for returning an error message instead: when concurrent validators on the same chain are sending signing messages. This was proposed by @mdyring in #249.

Ideally there should be coordination (i.e. between KMS instances) as to which validator is currently active, as this approach depends critically on the KMS's double signing prevention and encourages configurations where multiple validator instances are attempting to sign simultaneously. This runs the risk that a bug in the KMS's double signing detection could be singularly responsible for a double sign event.

However, without something like this, it isn't possible for the KMS to service two validators simultaneously, so this seems like an OK start with some nice HA benefits.