### PR TITLE
yubihsm keys list: Use chain-specific formatters (fixes #253)

### DIFF
--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,8 +1,9 @@
 //! List keys inside the YubiHSM2
 
+use crate::{application::app_config, chain, keyring};
 use abscissa::{Command, Runnable};
-use std::process;
-use tendermint::PublicKey;
+use std::{collections::BTreeMap as Map, process};
+use tendermint::{PublicKey, TendermintKey};
 
 /// The `yubihsm keys list` subcommand
 #[derive(Command, Debug, Default, Options)]
@@ -15,6 +16,7 @@ pub struct ListCommand {
 impl Runnable for ListCommand {
     /// List all suitable Ed25519 keys in the HSM
     fn run(&self) {
+        let key_formatters = load_key_formatters();
         let hsm = crate::yubihsm::client();
 
         let serial_number = hsm
@@ -57,16 +59,58 @@ impl Runnable for ListCommand {
             let key_id = format!("- 0x#{:04x}", key.object_id);
 
             // TODO: support for non-Ed25519 keys
-            if public_key.algorithm == yubihsm::asymmetric::Algorithm::Ed25519 {
-                status_attr_ok!(
-                    key_id,
-                    PublicKey::from_raw_ed25519(&public_key.as_ref())
-                        .unwrap()
-                        .to_hex()
-                );
-            } else {
+            if public_key.algorithm != yubihsm::asymmetric::Algorithm::Ed25519 {
                 status_attr_err!(key_id, "unsupported algorithm: {:?}", public_key.algorithm);
+                continue;
+            }
+
+            // TODO: support for account keys
+            let tendermint_key = TendermintKey::ConsensusKey(
+                PublicKey::from_raw_ed25519(&public_key.as_ref()).unwrap(),
+            );
+
+            let public_key_serialized = match key_formatters.get(&key.object_id) {
+                Some(key_formatter) => key_formatter.serialize(tendermint_key),
+                None => tendermint_key.to_hex(),
+            };
+
+            status_attr_ok!(key_id, public_key_serialized);
+        }
+    }
+}
+
+/// Load information about configured YubiHSM keys
+fn load_key_formatters() -> Map<u16, keyring::Format> {
+    let chain_formatters = load_chain_formatters();
+    let cfg = crate::yubihsm::config();
+    let mut map = Map::new();
+
+    for key_config in &cfg.keys {
+        // Only use a preferred formatting if there is one chain per key
+        if key_config.chain_ids.len() == 1 {
+            if let Some(formatter) = chain_formatters.get(&key_config.chain_ids[0]) {
+                if map.insert(key_config.key, formatter.clone()).is_some() {
+                    status_err!("duplicate YubiHSM config for key: 0x{:04x}", key_config.key);
+                    process::exit(1);
+                }
             }
         }
     }
+
+    map
+}
+
+/// Load chain-specific key formatters from the configuration
+fn load_chain_formatters() -> Map<chain::Id, keyring::Format> {
+    let cfg = app_config();
+    let mut map = Map::new();
+
+    for chain in &cfg.chain {
+        if map.insert(chain.id, chain.key_format.clone()).is_some() {
+            status_err!("duplicate chain config for '{}'", chain.id);
+            process::exit(1);
+        }
+    }
+
+    map
 }

--- a/src/keyring/ed25519/mod.rs
+++ b/src/keyring/ed25519/mod.rs
@@ -4,7 +4,7 @@ pub use signatory::ed25519::{PublicKey, Seed, Signature, PUBLIC_KEY_SIZE};
 
 #[cfg(feature = "ledgertm")]
 pub mod ledgertm;
-mod signer;
+pub mod signer;
 #[cfg(feature = "softsign")]
 pub mod softsign;
 #[cfg(feature = "yubihsm")]

--- a/src/keyring/ed25519/signer.rs
+++ b/src/keyring/ed25519/signer.rs
@@ -1,3 +1,5 @@
+//! Wrapper for Ed25519 signers
+
 use crate::{
     error::{Error, ErrorKind::*},
     keyring::SigningProvider,
@@ -6,7 +8,7 @@ use signatory::ed25519::Signature;
 use std::sync::Arc;
 use tendermint::TendermintKey;
 
-/// Wrapper for an Ed25519 signing provider (i.e. trait object)
+/// Trait object wrapper for an Ed25519 signers
 #[derive(Clone)]
 pub struct Signer {
     /// Provider for this signer

--- a/src/keyring/mod.rs
+++ b/src/keyring/mod.rs
@@ -1,8 +1,8 @@
 //! Signing keyring. Presently specialized for Ed25519.
 
 pub mod ed25519;
-mod format;
-mod providers;
+pub mod format;
+pub mod providers;
 
 use self::ed25519::Signer;
 pub use self::{format::Format, providers::SigningProvider};

--- a/src/keyring/providers.rs
+++ b/src/keyring/providers.rs
@@ -1,3 +1,5 @@
+//! Signature providers (i.e. backends/plugins)
+
 use std::fmt::{self, Display};
 
 /// Enumeration of signing key providers


### PR DESCRIPTION
Use configured chain-specific formatters when listing keys in YubiHSMs.