### PR TITLE
tendermint-rs v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1324,7 +1324,7 @@ dependencies = [
  "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.8.0",
+ "tendermint 0.9.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.26.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ yubihsm = { version = "0.26", features = ["setup", "usb"], optional = true }
 zeroize = "0.9"
 
 [dependencies.tendermint]
-version = "0.8"
+version = "0.9"
 path = "tendermint-rs"
 features = ["amino-types", "secret-connection"]
 

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.9.0] (2019-06-24)
+
+This release is compatible with [tendermint v0.31]
+
+- Reject low order points in Secret Connection handshake ([#279])
+- Add `RemoteErrorCode` enum ([#272])
+- Add `msg_type()` accessor for signature types ([#271])
+
 ## [0.8.0] (2019-06-20)
 
 This release is compatible with [tendermint v0.31]
@@ -73,6 +81,10 @@ This release is compatible with [tendermint v0.28]
 
 - Initial release
 
+[0.9.0]: https://github.com/tendermint/kms/pull/280
+[#279]: https://github.com/tendermint/kms/pull/279
+[#272]: https://github.com/tendermint/kms/pull/272
+[#271]: https://github.com/tendermint/kms/pull/271
 [0.8.0]: https://github.com/tendermint/kms/pull/269
 [#268]: https://github.com/tendermint/kms/pull/268
 [#267]: https://github.com/tendermint/kms/pull/267

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.8.0" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.9.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -15,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.8.0"
+    html_root_url = "https://docs.rs/tendermint/0.9.0"
 )]
 
 #[cfg(feature = "amino-types")]


### PR DESCRIPTION
This release is compatible with [tendermint v0.31]

 - Reject low order points in Secret Connection handshake (#279)
- Add `RemoteErrorCode` enum (#272)
- Add `msg_type()` accessor for signature types (#271)

[tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0310