### PR TITLE
Add serde(deny_unknown_fields) to all config structs

### DIFF
--- a/src/config/chain.rs
+++ b/src/config/chain.rs
@@ -9,6 +9,7 @@ use std::path::PathBuf;
 
 /// Chain configuration
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ChainConfig {
     /// Chain ID of this Tendermint network/chain
     pub id: chain::Id,

--- a/src/config/chain/hook.rs
+++ b/src/config/chain/hook.rs
@@ -3,6 +3,7 @@ use std::ffi::OsString;
 
 /// Configuration for a particular hook to invoke
 #[derive(Default, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct HookConfig {
     /// Command (with arguments) to invoke
     pub cmd: Vec<OsString>,

--- a/src/config/provider.rs
+++ b/src/config/provider.rs
@@ -17,6 +17,7 @@ use serde::Deserialize;
 
 /// Provider configuration
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ProviderConfig {
     /// Software-backed signer
     #[cfg(feature = "softsign")]

--- a/src/config/provider/ledgertm.rs
+++ b/src/config/provider/ledgertm.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 
 /// Ledger Tendermint signer configuration
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct LedgerTendermintConfig {
     /// Chains this signing key is authorized to be used from
     pub chain_ids: Vec<chain::Id>,

--- a/src/config/provider/softsign.rs
+++ b/src/config/provider/softsign.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 /// Software signer configuration
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SoftSignConfig {
     /// Chains this signing key is authorized to be used from
     pub chain_ids: Vec<chain::Id>,
@@ -17,6 +18,7 @@ pub struct SoftSignConfig {
 
 /// Software-backed private key (stored in a file)
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct SoftPrivateKey(PathBuf);
 
 impl SoftPrivateKey {

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -6,6 +6,7 @@ use tendermint::{chain, net};
 
 /// Validator configuration
 #[derive(Clone, Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct ValidatorConfig {
     /// Address of the validator (`tcp://` or `unix://`)
     pub addr: net::Address,


### PR DESCRIPTION
By default serde ignores unknown fields. This is nice for RPC, but less so for configuration files.

This annotates every config struct with `serde(deny_unknown_fields)` so as to catch things like spelling mistakes or keys that are in the wrong location.