### PR TITLE
tendermint-rs: Add tests for `net::Address` parsing

### DIFF
--- a/tendermint-rs/src/net.rs
+++ b/tendermint-rs/src/net.rs
@@ -94,3 +94,34 @@ impl Serialize for Address {
         self.to_string().serialize(serializer)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node;
+
+    /// Example TCP node address
+    const EXAMPLE_TCP_STR: &str =
+        "tcp://abd636b766dcefb5322d8ca40011ec2cb35efbc2@35.192.61.41:26656";
+
+    #[test]
+    fn parse_tcp_addr() {
+        match EXAMPLE_TCP_STR.parse::<Address>().unwrap() {
+            Address::Tcp {
+                peer_id,
+                host,
+                port,
+            } => {
+                assert_eq!(
+                    peer_id.unwrap(),
+                    "abd636b766dcefb5322d8ca40011ec2cb35efbc2"
+                        .parse::<node::Id>()
+                        .unwrap()
+                );
+                assert_eq!(host, "35.192.61.41");
+                assert_eq!(port, 26656);
+            }
+            other => panic!("unexpected address type: {:?}", other),
+        }
+    }
+}

--- a/tendermint-rs/src/node/id.rs
+++ b/tendermint-rs/src/node/id.rs
@@ -16,7 +16,8 @@ use subtle_encoding::hex;
 pub const LENGTH: usize = 20;
 
 /// Node IDs
-#[derive(Copy, Clone, Hash)]
+#[allow(clippy::derive_hash_xor_eq)]
+#[derive(Copy, Clone, Eq, Hash)]
 pub struct Id([u8; LENGTH]);
 
 impl Id {
@@ -38,7 +39,6 @@ impl AsRef<[u8]> for Id {
 }
 
 impl ConstantTimeEq for Id {
-    #[inline]
     fn ct_eq(&self, other: &Id) -> subtle::Choice {
         self.as_bytes().ct_eq(other.as_bytes())
     }
@@ -85,6 +85,12 @@ impl FromStr for Id {
         let mut result_bytes = [0u8; LENGTH];
         result_bytes.copy_from_slice(&bytes);
         Ok(Id(result_bytes))
+    }
+}
+
+impl PartialEq for Id {
+    fn eq(&self, other: &Id) -> bool {
+        self.ct_eq(other).into()
     }
 }
 


### PR DESCRIPTION
This just tests `net::Address::Tcp` parsing. It'd probably be good to have a test for `net::Address:Unix` too.

I was attempting to regression test a parsing bug I'm experiencing elsewhere, but this seems to be working, so I'm a little confused.

Anyway, tests are good.