### PR TITLE
yubihsm setup: use hkd32 crate to derive key hierarchy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkd32"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hkdf"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1411,7 @@ dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "gumdrop 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hkd32 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hkdf 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1701,6 +1712,7 @@ dependencies = [
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hidapi 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "25440089a47b7c63b7a3515d1cdfcd0ac3d649fdc360540944e05c4e7899b4fe"
+"checksum hkd32 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9f98e3f58887b221d4403fe5dddb635b13a6fc5ae65c35b14f8d464b2e55fcb1"
 "checksum hkdf 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "35e8f9d776bbe83f1ff24951f7cc19140fb7ff8d0378463c4c4955f6b0d3e503"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "0.4"
 chrono = "0.4"
 failure = "0.1"
 gumdrop = "0.6"
+hkd32 = { version = "0.1.2", default-features = false }
 hkdf = "0.7"
 hmac = "0.7"
 lazy_static = "1"


### PR DESCRIPTION
`hkd32` is an implementation of the same hierarchical key derivation algorithm the KMS was previously using, which is an extracted subset of the symmetric parts of BIP32 derivation (to the point it could potentially be used to implement a full BIP32).

The `hkd32` crate has the advantage of using a [zeroize](https://crates.io/crates/zeroize)-on-drop type for all key material, as opposed to some of the manual zeroization this crate was previously using. In addition, it has some richer types for things like derivation paths, which may be potentially useful in the future.

There is one case that deviated from the previous implementation, which is the behavior of calling derive with an empty derivation path. Before it would output the "chain code" derived after inputting the `DERIVATION_VERSION`, whereas when using `hkd32` it correctly outputs the other half of the derived key material, which is intended to be used as a secret key.

Nothing presently calls the derivation function with an empty derivation path, except for a test I just added today in #299. While the output for this case differs, it has no practical impact, and if anything the function outputting the raw chain code for the first level of the hierarchy (which is the version number) is a sharp edge that could potentially leak what is the root key to the entire hierarchy if it were to be called with an empty derivation path.

`hkd32` uses a fully uniform derivation algorithm which treats the `DERIVATION_VERSION` like any other part of the path, and therefore does not have this sharp edge.

Test vectors for path lengths of 1, 2, and 3 all pass with the original vectors.