### PR TITLE
tendermint-rs: Fix feature gating on signatory-dalek + CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
           cargo build --features=yubihsm-server
           cargo build --features=ledgertm
           cargo build --features=yubihsm-server,ledgertm,softsign
-          cd tendermint-rs && cargo build --no-default-features
+          cd tendermint-rs && cargo build --no-default-features && cargo build --features=config && cargo build --features=rpc
     - run:
         name: build --release
         command: |

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -58,7 +58,7 @@ serde_json = "1"
 [features]
 default = ["serde", "tai64"]
 amino-types = ["prost-amino", "prost-amino-derive"]
-config = ["serde", "serde_json", "toml"]
+config = ["serde", "serde_json", "toml", "zeroize"]
 rpc = ["hyper", "rand_os", "serde", "serde_json", "uuid"]
 secret-connection = [
     "amino-types",

--- a/tendermint-rs/src/config/node_key.rs
+++ b/tendermint-rs/src/config/node_key.rs
@@ -2,10 +2,10 @@
 
 use crate::{
     error::{Error, ErrorKind},
-    node,
     private_key::PrivateKey,
-    public_key::PublicKey,
 };
+#[cfg(feature = "signatory-dalek")]
+use crate::{node, public_key::PublicKey};
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
 
@@ -40,6 +40,7 @@ impl NodeKey {
     }
 
     /// Get the public key for this keypair
+    #[cfg(feature = "signatory-dalek")]
     pub fn public_key(&self) -> PublicKey {
         match &self.priv_key {
             PrivateKey::Ed25519(key) => key.public_key(),
@@ -47,6 +48,7 @@ impl NodeKey {
     }
 
     /// Get node ID for this keypair
+    #[cfg(feature = "signatory-dalek")]
     pub fn node_id(&self) -> node::Id {
         match &self.public_key() {
             PublicKey::Ed25519(key) => node::Id::from(*key),

--- a/tendermint-rs/src/config/priv_validator_key.rs
+++ b/tendermint-rs/src/config/priv_validator_key.rs
@@ -1,10 +1,12 @@
 //! Validator private keys
 
+#[cfg(feature = "signatory-dalek")]
+use crate::public_key::TendermintKey;
 use crate::{
     account,
     error::{Error, ErrorKind},
     private_key::PrivateKey,
-    public_key::{PublicKey, TendermintKey},
+    public_key::PublicKey,
 };
 use serde::{Deserialize, Serialize};
 use std::{fs, path::Path};
@@ -28,6 +30,7 @@ impl PrivValidatorKey {
         let result = serde_json::from_str::<Self>(json_string.as_ref())?;
 
         // Validate that the parsed key type is usable as a consensus key
+        #[cfg(feature = "signatory-dalek")]
         TendermintKey::new_consensus_key(result.priv_key.public_key())?;
 
         Ok(result)
@@ -51,6 +54,7 @@ impl PrivValidatorKey {
     }
 
     /// Get the consensus public key for this validator private key
+    #[cfg(feature = "signatory-dalek")]
     pub fn consensus_pubkey(&self) -> TendermintKey {
         TendermintKey::new_consensus_key(self.priv_key.public_key()).unwrap()
     }

--- a/tendermint-rs/src/private_key.rs
+++ b/tendermint-rs/src/private_key.rs
@@ -1,8 +1,11 @@
 //! Cryptographic private keys
 
+#[cfg(feature = "signatory-dalek")]
 use crate::public_key::PublicKey;
 use serde::{de, de::Error as _, ser, Deserialize, Serialize};
-use signatory::{ed25519, PublicKeyed};
+use signatory::ed25519;
+#[cfg(feature = "signatory-dalek")]
+use signatory::PublicKeyed;
 #[cfg(feature = "signatory-dalek")]
 use signatory_dalek::Ed25519Signer;
 use subtle_encoding::{Base64, Encoding};
@@ -22,6 +25,7 @@ pub enum PrivateKey {
 
 impl PrivateKey {
     /// Get the public key associated with this private key
+    #[cfg(feature = "signatory-dalek")]
     pub fn public_key(&self) -> PublicKey {
         match self {
             PrivateKey::Ed25519(private_key) => private_key.public_key(),
@@ -43,6 +47,7 @@ pub struct Ed25519Keypair([u8; ED25519_KEYPAIR_SIZE]);
 
 impl Ed25519Keypair {
     /// Get the public key associated with this keypair
+    #[cfg(feature = "signatory-dalek")]
     pub fn public_key(&self) -> PublicKey {
         let seed = ed25519::Seed::from_keypair(&self.0[..]).unwrap();
         let pk = signatory_dalek::Ed25519Signer::from(&seed)


### PR DESCRIPTION
There are now several functions which rely on the ability to compute Ed25519 public keys from private scalars, and use `signatory-dalek` to do that.

However, those weren't properly `cfg` gated, so in those cases the crate wouldn't compile.

Additionally the `config` feature didn't pull in `zeroize`, a required dependency. That was corrected by adding it.