### PR TITLE
Display tendermint::consensus::State height/round/step

### DIFF
--- a/src/session.rs
+++ b/src/session.rs
@@ -186,8 +186,8 @@ where
                     let height = request.height().unwrap();
 
                     warn!(
-                        "[{}:{}] attempt to double sign at height: {}",
-                        &self.chain_id, &self.peer_addr, height
+                        "[{}:{}] attempt to double sign at height/round/step: {}",
+                        &self.chain_id, &self.peer_addr, request_state
                     );
 
                     let remote_err = RemoteError::double_sign(height);
@@ -242,8 +242,8 @@ where
 
     /// Write an INFO logline about a signing request
     fn log_signing_request<T: TendermintRequest + Debug>(&self, request: &T, started_at: Instant) {
-        let height = request
-            .height()
+        let consensus_state = request
+            .consensus_state()
             .map(|h| h.to_string())
             .unwrap_or_else(|| "none".to_owned());
 
@@ -253,11 +253,11 @@ where
             .unwrap_or_else(|| "Unknown".to_owned());
 
         info!(
-            "[{}@{}] signed {:?} at height: {} ({} ms)",
+            "[{}@{}] signed {:?} at height/round/step: {} ({} ms)",
             &self.chain_id,
             &self.peer_addr,
             msg_type,
-            height,
+            consensus_state,
             started_at.elapsed().as_millis()
         );
     }

--- a/tendermint-rs/src/consensus/state.rs
+++ b/tendermint-rs/src/consensus/state.rs
@@ -1,7 +1,7 @@
 //! Tendermint consensus state
 
 pub use crate::block;
-pub use std::cmp::Ordering;
+pub use std::{cmp::Ordering, fmt};
 #[cfg(feature = "serde")]
 use {
     crate::serializers,
@@ -30,6 +30,12 @@ pub struct State {
 
     /// Block ID being proposed (if available)
     pub block_id: Option<block::Id>,
+}
+
+impl fmt::Display for State {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}/{}", self.height, self.round, self.step)
+    }
 }
 
 impl Ord for State {


### PR DESCRIPTION
Displaying just the block height when signing may give the impression that double signing is occurring when it's signing for different rounds at the same height (because e.g. the block at a particular round for a given height failed to commit).

This displays all three values instead.