### PR TITLE
Log block ID and [dup] blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,9 +3,8 @@
 [[package]]
 name = "abscissa_core"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "abscissa_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abscissa_derive 0.2.0",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,7 +25,6 @@ dependencies = [
 [[package]]
 name = "abscissa_derive"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1404,7 +1402,7 @@ dependencies = [
 name = "tmkms"
 version = "0.6.0-rc1"
 dependencies = [
- "abscissa_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "abscissa_core 0.2.0",
  "atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1656,8 +1654,6 @@ dependencies = [
 ]
 
 [metadata]
-"checksum abscissa_core 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0bdd7e718d3a402cc8d3a5162c001d2b5e9442e95bab3ae8fbb391ceaa869541"
-"checksum abscissa_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a82cd833c86788c6ea78c1c2bf1f7061b0a303f53acf154f3c8c3bbba21a0859"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
 "checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -165,6 +165,15 @@ impl State {
 
         Ok(())
     }
+
+    /// Determine if a requested signing operation duplicates a previous one,
+    /// i.e. if the height/round/step and block ID are identical.
+    ///
+    /// This is used to signal to the user that a duplicate signing event
+    /// has occurred.
+    pub fn is_dup(&self, consensus_state: &consensus::State) -> bool {
+        &self.consensus_state == consensus_state
+    }
 }
 
 #[cfg(test)]

--- a/src/session.rs
+++ b/src/session.rs
@@ -176,9 +176,24 @@ where
         let registry = chain::REGISTRY.get();
         let chain = registry.get_chain(&self.chain_id).unwrap();
 
-        if let Some(request_state) = request.consensus_state() {
+        // The current double-signing logic allows for resigning the exact
+        // same block as the one it signed immediately prior, i.e. if the
+        // requested block ID is identical, and the height/round/step are
+        // identical, (re)computing the signature is allowed.
+        //
+        // Since Ed25519 is a deterministic signature algorithm, this has no
+        // deleterious effects, and provides fault tolerance in the event
+        // the KMS hands a signed block off to a validator that drops it
+        // on the floor (e.g. hardware failure)
+        //
+        // When this happens, this flag is set to notify the user that it
+        // signed a duplicate block.
+        let mut is_dup = false;
+
+        if let Some(request_state) = &request.consensus_state() {
             // TODO(tarcieri): better handle `PoisonError`?
             let mut chain_state = chain.state.lock().unwrap();
+            is_dup = chain_state.is_dup(request_state);
 
             if let Err(e) = chain_state.update_consensus_state(request_state.clone()) {
                 // Report double signing error back to the validator
@@ -218,7 +233,7 @@ where
         let started_at = Instant::now();
         let signature = chain.keyring.sign_ed25519(None, &to_sign)?;
 
-        self.log_signing_request(&request, started_at);
+        self.log_signing_request(&request, started_at, is_dup);
         request.set_signature(&signature);
 
         Ok(request.build_response(None))
@@ -241,24 +256,44 @@ where
     }
 
     /// Write an INFO logline about a signing request
-    fn log_signing_request<T: TendermintRequest + Debug>(&self, request: &T, started_at: Instant) {
-        let consensus_state = request
-            .consensus_state()
-            .map(|h| h.to_string())
-            .unwrap_or_else(|| "none".to_owned());
+    fn log_signing_request<T: TendermintRequest + Debug>(
+        &self,
+        request: &T,
+        started_at: Instant,
+        is_dup: bool,
+    ) {
+        let (consensus_state, block_id) = match &request.consensus_state() {
+            Some(state) => {
+                let block_id_string = match &state.block_id {
+                    Some(id) => {
+                        let mut res = id.to_string();
+                        res.truncate(8);
+                        res
+                    }
+                    None => "none".to_owned(),
+                };
+
+                (state.to_string(), block_id_string)
+            }
+            None => ("none".to_owned(), "none".to_owned()),
+        };
 
         let msg_type = request
             .msg_type()
             .map(|t| format!("{:?}", t))
             .unwrap_or_else(|| "Unknown".to_owned());
 
+        let dup_msg = if is_dup { " [dup]" } else { "" };
+
         info!(
-            "[{}@{}] signed {:?} at height/round/step: {} ({} ms)",
+            "[{}@{}] signed {}:{} h/r/s:{} ({} ms){}",
             &self.chain_id,
             &self.peer_addr,
             msg_type,
+            block_id,
             consensus_state,
-            started_at.elapsed().as_millis()
+            started_at.elapsed().as_millis(),
+            dup_msg
         );
     }
 }


### PR DESCRIPTION
Logs a truncated ID of every block that is requested to be signed.

The idea is to help users of the KMS understand what is happening when multiple concurrent validators attempt to (re)sign the same block.

Additionally this adds a small `[dup]` flag when resiging the same block is requested, to let users know that the KMS is aware it resigned a block at the same height/round/step, but that's OK because it has the same block ID and will produce the same signature, so rather than it
being a "double signing" event, it's merely recomputing the same signature on the block it originally signed.