### PR TITLE
Log block ID prefix in more contexts; remove dup logging (closes #314)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "abscissa_core"
-version = "0.2.0"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "abscissa_derive 0.2.0",
+ "abscissa_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "canonical-path 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,6 +26,7 @@ dependencies = [
 [[package]]
 name = "abscissa_derive"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -468,7 +470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1063,7 +1065,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1157,7 +1159,7 @@ dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1170,7 +1172,7 @@ dependencies = [
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signature 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1252,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1343,7 +1345,7 @@ dependencies = [
  "toml 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1402,7 +1404,7 @@ dependencies = [
 name = "tmkms"
 version = "0.6.0-rc1"
 dependencies = [
- "abscissa_core 0.2.0",
+ "abscissa_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1416,7 +1418,7 @@ dependencies = [
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-amino-derive 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpassword 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.95 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1434,7 +1436,7 @@ dependencies = [
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1631,12 +1633,12 @@ dependencies = [
  "tiny_http 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zeroize"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1654,6 +1656,8 @@ dependencies = [
 ]
 
 [metadata]
+"checksum abscissa_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "959985f7878f5f3cc70894ed736dacef6751398f010995860054e59a2b17c099"
+"checksum abscissa_derive 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a82cd833c86788c6ea78c1c2bf1f7061b0a303f53acf154f3c8c3bbba21a0859"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
 "checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
@@ -1836,5 +1840,5 @@ dependencies = [
 "checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"
 "checksum x25519-dalek 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
 "checksum yubihsm 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b66dcc264cbb543bc6ac6ea2400f841f531544a61e1a1a7346636bc63381811e"
-"checksum zeroize 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4177936c03b5a349c1b8e4509c46add268e66bc66fe92663729fa0570fe4f213"
+"checksum zeroize 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
 "checksum zeroize_derive 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afd1469e4bbca3b96606d26ba6e9bd6d3aed3b1299c82b92ec94377d22d78dbc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [".", "tendermint-rs"]
 circle-ci = { repository = "tendermint/kms" }
 
 [dependencies]
+abscissa_core = "0.2"
 atomicwrites = "0.2"
 byteorder = "1.2"
 bytes = "0.4"
@@ -47,9 +48,6 @@ wait-timeout = "0.2"
 yubihsm = { version = "0.26", features = ["setup", "usb"], optional = true }
 zeroize = "0.9"
 
-[dependencies.abscissa_core]
-version = "0.2"
-
 [dependencies.tendermint]
 version = "0.10.0-rc0"
 path = "tendermint-rs"
@@ -57,7 +55,7 @@ features = ["amino-types", "config", "secret-connection"]
 
 [dev-dependencies]
 tempfile = "3"
-rand = "0.6"
+rand = "0.7"
 
 [dev-dependencies.abscissa_core]
 version = "0.2"

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -60,6 +60,11 @@ impl State {
         }
     }
 
+    /// Borrow the current consensus state
+    pub fn consensus_state(&self) -> &consensus::State {
+        &self.consensus_state
+    }
+
     /// Check and update the chain's height, round, and step
     pub fn update_consensus_state(
         &mut self,
@@ -164,15 +169,6 @@ impl State {
             .write(|f| f.write_all(json.as_bytes()))?;
 
         Ok(())
-    }
-
-    /// Determine if a requested signing operation duplicates a previous one,
-    /// i.e. if the height/round/step and block ID are identical.
-    ///
-    /// This is used to signal to the user that a duplicate signing event
-    /// has occurred.
-    pub fn is_dup(&self, consensus_state: &consensus::State) -> bool {
-        &self.consensus_state == consensus_state
     }
 }
 

--- a/tendermint-rs/src/block/id.rs
+++ b/tendermint-rs/src/block/id.rs
@@ -10,6 +10,9 @@ use std::{
     str::{self, FromStr},
 };
 
+/// Length of a block ID prefix displayed for debugging purposes
+pub const PREFIX_LENGTH: usize = 10;
+
 /// Block identifiers which contain two distinct Merkle roots of the block,
 /// as well as the number of parts in the block.
 ///
@@ -40,6 +43,13 @@ impl Id {
     /// Create a new `Id` from a hash byte slice
     pub fn new(hash: Hash, parts: Option<parts::Header>) -> Self {
         Self { hash, parts }
+    }
+
+    /// Get a shortened 12-character prefix of a block ID (ala git)
+    pub fn prefix(&self) -> String {
+        let mut result = self.to_string();
+        result.truncate(PREFIX_LENGTH);
+        result
     }
 }
 

--- a/tendermint-rs/src/consensus/state.rs
+++ b/tendermint-rs/src/consensus/state.rs
@@ -32,6 +32,16 @@ pub struct State {
     pub block_id: Option<block::Id>,
 }
 
+impl State {
+    /// Get short prefix of the block ID for debugging purposes (ala git)
+    pub fn block_id_prefix(&self) -> String {
+        self.block_id
+            .as_ref()
+            .map(block::Id::prefix)
+            .unwrap_or_else(|| "(none)".to_owned())
+    }
+}
+
 impl fmt::Display for State {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}/{}/{}", self.height, self.round, self.step)


### PR DESCRIPTION
This logs the block ID prefixes in the event double signing is detected.

It also removes the "dup" logging, which is complex and buggy. A simpler implementation may be possible, but delayed until at least another release.