### PR TITLE
tendermint-rs: Derive Eq/Ord for (transitive) status types

### DIFF
--- a/tendermint-rs/src/account.rs
+++ b/tendermint-rs/src/account.rs
@@ -16,7 +16,7 @@ use subtle_encoding::hex;
 const LENGTH: usize = 20;
 
 /// Account IDs
-#[derive(Copy, Clone, Hash)]
+#[derive(Copy, Clone, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct Id([u8; LENGTH]);
 
 impl Id {

--- a/tendermint-rs/src/block/id.rs
+++ b/tendermint-rs/src/block/id.rs
@@ -18,7 +18,7 @@ pub const PREFIX_LENGTH: usize = 10;
 ///
 /// <https://github.com/tendermint/tendermint/blob/master/docs/spec/blockchain/blockchain.md#blockid>
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Id {
     /// The block's main hash is the Merkle root of all the fields in the
     /// block header.

--- a/tendermint-rs/src/block/parts.rs
+++ b/tendermint-rs/src/block/parts.rs
@@ -9,7 +9,7 @@ use {
 
 /// Block parts header
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+#[derive(Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Header {
     /// Number of parts in this block
     #[cfg_attr(

--- a/tendermint-rs/src/hash.rs
+++ b/tendermint-rs/src/hash.rs
@@ -20,7 +20,7 @@ pub enum Algorithm {
 }
 
 /// Hash digests
-#[derive(Copy, Clone, Hash, Eq, PartialEq)]
+#[derive(Copy, Clone, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub enum Hash {
     /// SHA-256 hashes
     Sha256([u8; SHA256_HASH_SIZE]),

--- a/tendermint-rs/src/node/id.rs
+++ b/tendermint-rs/src/node/id.rs
@@ -17,7 +17,7 @@ pub const LENGTH: usize = 20;
 
 /// Node IDs
 #[allow(clippy::derive_hash_xor_eq)]
-#[derive(Copy, Clone, Eq, Hash)]
+#[derive(Copy, Clone, Eq, Hash, PartialOrd, Ord)]
 pub struct Id([u8; LENGTH]);
 
 impl Id {

--- a/tendermint-rs/src/node/info.rs
+++ b/tendermint-rs/src/node/info.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display};
 
 /// Node information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Info {
     /// Protocol version information
     pub protocol_version: ProtocolVersionInfo,
@@ -33,7 +33,7 @@ pub struct Info {
 }
 
 /// Protocol version information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProtocolVersionInfo {
     /// P2P protocol version
     #[serde(
@@ -58,7 +58,7 @@ pub struct ProtocolVersionInfo {
 }
 
 /// Listen address information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ListenAddress(String);
 
 impl ListenAddress {
@@ -80,7 +80,7 @@ impl Display for ListenAddress {
 }
 
 /// Other information
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct OtherInfo {
     /// TX index status
     pub tx_index: TxIndexStatus,
@@ -90,7 +90,7 @@ pub struct OtherInfo {
 }
 
 /// Transaction index status
-#[derive(Copy, Clone, Debug, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub enum TxIndexStatus {
     /// Index is on
     #[serde(rename = "on")]

--- a/tendermint-rs/src/validator.rs
+++ b/tendermint-rs/src/validator.rs
@@ -8,7 +8,7 @@ use subtle_encoding::base64;
 
 /// Validator information
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Info {
     /// Validator account address
     pub address: account::Id,
@@ -60,7 +60,7 @@ impl Serialize for ProposerPriority {
 
 /// Updates to the validator set
 #[cfg(feature = "rpc")]
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Update {
     /// Validator public key
     #[serde(deserialize_with = "deserialize_public_key")]


### PR DESCRIPTION
This makes comparing them and using them in data structures (e.g. HashMap, BTreeMap) easier/possible.