### PR TITLE
tendermint-rs: Fix error for not using inclusive range

### DIFF
--- a/tendermint-rs/src/timeout.rs
+++ b/tendermint-rs/src/timeout.rs
@@ -38,7 +38,7 @@ impl FromStr for Timeout {
 
         let units = match s.chars().nth(s.len() - 2) {
             Some('m') => "ms",
-            Some('0'...'9') => "s",
+            Some('0'..='9') => "s",
             _ => Err(err!(ErrorKind::Parse, "invalid units"))?,
         };
 


### PR DESCRIPTION
Compilation with nightly fails:
```
error: `...` range patterns are deprecated
  --> tendermint-rs/src/timeout.rs:41:21
   |                                 
41 |             Some('0'...'9') => "s",
   |                     ^^^ help: use `..=` for an inclusive range
   |                                 
```
