### PR TITLE
tendermint-rs v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "tendermint"
-version = "0.10.0-rc1"
+version = "0.10.0"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1428,7 +1428,7 @@ dependencies = [
  "subtle 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle-encoding 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tendermint 0.10.0-rc1",
+ "tendermint 0.10.0",
  "tiny-bip39 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "yubihsm 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ yubihsm = { version = "0.26", features = ["setup", "usb"], optional = true }
 zeroize = "0.9"
 
 [dependencies.tendermint]
-version = "0.10.0-rc1"
+version = "0.10"
 path = "tendermint-rs"
 features = ["amino-types", "config", "secret-connection"]
 

--- a/tendermint-rs/CHANGES.md
+++ b/tendermint-rs/CHANGES.md
@@ -1,3 +1,17 @@
+## [0.10.0] (2019-07-30)
+
+This release is tested against [tendermint v0.31] and known to be compatible
+with [tendermint v0.32] aside from one known issue impacting RPC ([#286]).
+
+- Fix inclusive range incompatibility affecting Rust nightly ([#326])
+- Derive Eq/Ord for (transitive) status types ([#324])
+- Add `TendermintConfig::load_node_key` ([#315])
+- Add `TendermintConfig::load_genesis_file` ([#312])
+- Add `TendermintConfig` and `Error(Kind)` types ([#298])
+- Support `/abci_query` RPC endpoint ([#296])
+- Implement the Tendermint (RFC6962) Merkle tree ([#292])
+- Support `account::Id` generation from ed25519 pubkeys ([#291])
+
 ## [0.9.0] (2019-06-24)
 
 This release is compatible with [tendermint v0.31]
@@ -81,6 +95,17 @@ This release is compatible with [tendermint v0.28]
 
 - Initial release
 
+[0.10.0]: https://github.com/tendermint/kms/pull/328
+[tendermint v0.32]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0320
+[#326]: https://github.com/tendermint/kms/pull/326
+[#324]: https://github.com/tendermint/kms/pull/324
+[#315]: https://github.com/tendermint/kms/pull/315
+[#312]: https://github.com/tendermint/kms/pull/312
+[#298]: https://github.com/tendermint/kms/pull/298
+[#296]: https://github.com/tendermint/kms/pull/296
+[#292]: https://github.com/tendermint/kms/pull/292
+[#291]: https://github.com/tendermint/kms/pull/291
+[#286]: https://github.com/tendermint/kms/pull/286
 [0.9.0]: https://github.com/tendermint/kms/pull/280
 [#279]: https://github.com/tendermint/kms/pull/279
 [#272]: https://github.com/tendermint/kms/pull/272

--- a/tendermint-rs/Cargo.toml
+++ b/tendermint-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name       = "tendermint"
-version    = "0.10.0-rc1" # Also update `html_root_url` in lib.rs when bumping this
+version    = "0.10.0" # Also update `html_root_url` in lib.rs when bumping this
 license    = "Apache-2.0"
 homepage   = "https://www.tendermint.com/"
 repository = "https://github.com/tendermint/kms/tree/master/crates/tendermint"

--- a/tendermint-rs/src/lib.rs
+++ b/tendermint-rs/src/lib.rs
@@ -15,7 +15,7 @@
 #![forbid(unsafe_code)]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tendermint/kms/master/img/tendermint.png",
-    html_root_url = "https://docs.rs/tendermint/0.10.0-rc1"
+    html_root_url = "https://docs.rs/tendermint/0.10.0"
 )]
 
 #[cfg(feature = "amino-types")]


### PR DESCRIPTION
This release is tested against [tendermint v0.31] and known to be compatible with [tendermint v0.32] aside from one known issue impacting RPC (#286).

- Fix inclusive range incompatibility affecting Rust nightly (#326)
- Derive Eq/Ord for (transitive) status types (#324)
- Add `TendermintConfig::load_node_key` (#315]
- Add `TendermintConfig::load_genesis_file` (#312)
- Add `TendermintConfig` and `Error(Kind)` types (#298)
- Support `/abci_query` RPC endpoint (#296)
- Implement the Tendermint (RFC6962) Merkle tree (#292)
- Support `account::Id` generation from ed25519 pubkeys (#291)

[tendermint v0.32]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0320
[tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0310