### PR TITLE
tmkms v0.6.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-## [0.6.0-rc1] (2019-07-25)
+## [0.6.0] (2019-07-30)
 
-This release is compatible with [tendermint v0.31].
+This release is tested against [tendermint v0.31] and known to be compatible
+with [tendermint v0.32].
 
 ### Upgrade Notes
 
@@ -53,7 +54,9 @@ section in the Tendermint KMS YubiHSM docs:
 
 ### Detailed Changes
 
-- [`tendermint` crate v0.10.0-rc0] ([#307])
+- [`tendermint` crate v0.10.0] ([#328])
+- Double signing logging improvements ([#322], [#319], [#317])
+- Log `tendermint::consensus::State` height/round/step ([#316])
 - `yubihsm keys import`: base64 support ([#306])
 - `yubihsm`: Support for reading password from a file ([#305])
 - `softsign`: Fix private key decoding + `import` command ([#304])
@@ -133,17 +136,23 @@ section in the Tendermint KMS YubiHSM docs:
 
 - Initial "preview" release
 
-[0.6.0-rc1]: https://github.com/tendermint/kms/pull/308
-[#307]: https://github.com/iqlusioninc/abscissa/pull/307
-[#306]: https://github.com/iqlusioninc/abscissa/pull/306
-[#305]: https://github.com/iqlusioninc/abscissa/pull/305
-[#304]: https://github.com/iqlusioninc/abscissa/pull/304
-[#303]: https://github.com/iqlusioninc/abscissa/pull/303
-[#302]: https://github.com/iqlusioninc/abscissa/pull/302
-[#300]: https://github.com/iqlusioninc/abscissa/pull/300
-[`abscissa` crate v0.2]: https://github.com/iqlusioninc/abscissa/pull/98
+[0.6.0]: https://github.com/tendermint/kms/pull/329
 [tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0316
-[`tendermint` crate v0.10.0-rc0]: https://github.com/tendermint/kms/pull/307
+[tendermint v0.32]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0320
+[`abscissa` crate v0.2]: https://github.com/iqlusioninc/abscissa/pull/98
+[`tendermint` crate v0.10.0]: https://github.com/tendermint/kms/pull/328
+[#328]: https://github.com/tendermint/kms/pull/328
+[#322]: https://github.com/tendermint/kms/pull/322
+[#319]: https://github.com/tendermint/kms/pull/319
+[#317]: https://github.com/tendermint/kms/pull/317
+[#316]: https://github.com/tendermint/kms/pull/316
+[#307]: https://github.com/tendermint/kms/pull/307
+[#306]: https://github.com/tendermint/kms/pull/306
+[#305]: https://github.com/tendermint/kms/pull/305
+[#304]: https://github.com/tendermint/kms/pull/304
+[#303]: https://github.com/tendermint/kms/pull/303
+[#302]: https://github.com/tendermint/kms/pull/302
+[#300]: https://github.com/tendermint/kms/pull/300
 [#294]: https://github.com/tendermint/kms/pull/288
 [#283]: https://github.com/tendermint/kms/pull/283
 [#282]: https://github.com/tendermint/kms/pull/282

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1398,7 +1398,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.6.0-rc1"
+version = "0.6.0"
 dependencies = [
  "abscissa_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.6.0-rc1"
+version     = "0.6.0"
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.6.0-rc1")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.6.0")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
This release is tested against [tendermint v0.31] and known to be compatible with [tendermint v0.32].

### Upgrade Notes

#### `state_file` syntax changes

The validator state files use an incompatible syntax from Tendermint KMS v0.5. It has been changed to match the conventions used by the rest of Tendermint, where integer values are stored in strings rather than JSON integers.

When upgrading, you will need to either *delete existing state files* (they will be recreated automatically), or ensure the integer `height` and `round` fields contained within these files are quoted in strings, e.g. `{"height":"123456","round":"0",...}`.

#### Unknown fields now disallowed in `tmkms.toml`

The previous parser for `tmkms.toml` ignored unknown attributes in the config file. This means it would often ignore syntax errors, spelling mistakes, or attributes in the wrong location when parsing files.

This has been changed to explicitly reject such fields, however please be aware if your config file contained invalid syntax, it will now be rejected by the parser and the KMS will no longer boot.

We suggest validating the configuration in a staging or other noncritical deployment of the KMS in order to ensure your configuration does not contain accidental misconfigurations which were previously uncaught.

See #282 for more information.

#### YubiHSM improvements

This release contains many improvements for users of the `yubihsm` backend:

- New `yubihsm-server` feature: this release includes support for the KMS exposing an HTTP service which is compatible with Yubico's `yubihsm-connector` service. This allows for concurrently administering a YubiHSM2 while the KMS is running, either through `tmkms yubihsm` (see additional notes below) or via Yubico's `yubihsm-shell`.
- Loopback support for `tmkms yubihsm`: the CLI functionality in the KMS for administering YubiHSMs can now be configured to connect to the KMS's own `yubihsm-server`. Additionally it can also be configured to use a different authentication key, and to prompt for a password as opposed to using one in the configuration file.

For more information on these changes, please see the "yubihsm-server feature" section in the Tendermint KMS YubiHSM docs:

<https://github.com/tendermint/kms/blob/master/README.yubihsm.md#yubihsm-server-feature>

### Detailed Changes

- [`tendermint` crate v0.10.0] (#328)
- Double signing logging improvements (#322, #319, #317)
- Log `tendermint::consensus::State` height/round/step (#316)
- `yubihsm keys import`: base64 support (#306)
- `yubihsm`: Support for reading password from a file (#305)
- `softsign`: Fix private key decoding + `import` command (#304)
- `softsign`: Add subcommand; move `keygen` under it (#303)
- `yubihsm setup`: use `hkd32` crate to derive key hierarchy (#302)
- `yubihsm setup`: Collect 256-bits entropy from both RNGs (#300)
- [`abscissa` crate v0.2] (#294)
- Log durations for each signing operation (#283)
- Add `serde(deny_unknown_fields)` to all config structs (#282)
- `tmkms yubihsm keys list`: Use chain-specific formatters (#275)
- `yubihsm-server`: Allow CLI commands to use loopback connection (#274)
- `yubihsm-server`: Optional `yubihsm-connector` compatibility (#273)
- Send `RemoteSignerError` response to validator on double sign (#249)
- Logging improvements (#271)
- yubihsm: Mark imported `priv_validator.json` keys as re-exportable (#248)
- ledger: Add init commands (#242)
- Add `max_height` support for stopping chains at specific heights (#238)
- Chain-specific keyrings / multitenancy (#232)
- ledger: Use `ledger-tendermint` backend (#225)

[tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0316
[tendermint v0.32]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0320
[`abscissa` crate v0.2]: https://github.com/iqlusioninc/abscissa/pull/98
[`tendermint` crate v0.10.0]: https://github.com/tendermint/kms/pull/328