### PR TITLE
Consider signed nil votes to be double signs

### DIFF
--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -99,9 +99,7 @@ impl State {
                     )
                 }
 
-                if new_state.block_id.is_some()
-                    && self.consensus_state.block_id.is_some()
-                    && self.consensus_state.block_id != new_state.block_id
+                if self.consensus_state.block_id != new_state.block_id
                 {
                     fail!(
                         StateErrorKind::DoubleSign,

--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -99,8 +99,7 @@ impl State {
                     )
                 }
 
-                if self.consensus_state.block_id != new_state.block_id
-                {
+                if self.consensus_state.block_id != new_state.block_id {
                     fail!(
                         StateErrorKind::DoubleSign,
                         "Attempting to sign a second proposal at height:{} round:{} step:{} old block id:{} new block {}",


### PR DESCRIPTION
Fixes #333

I had assumed signing a Nil block to be not considered an equivocation. I think that it shouldn't be. 