### PR TITLE
Allow some block id switches

### DIFF
--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -99,7 +99,12 @@ impl State {
                     )
                 }
 
-                if self.consensus_state.block_id != new_state.block_id {
+                if self.consensus_state.block_id != new_state.block_id &&
+                // If we incremented rounds allow locking on a new block
+                    new_state.round == self.consensus_state.round &&
+                // if we precommitting after prevoting nil allow locking on new block
+                     !(new_state.step == 3 && self.consensus_state.step == 2 && self.consensus_state.block_id.is_none())
+                {
                     fail!(
                         StateErrorKind::DoubleSign,
                         "Attempting to sign a second proposal at height:{} round:{} step:{} old block id:{} new block {}",


### PR DESCRIPTION
This basically enables switching a block id under some circumstances.

1. Round increment

2. Prevote a nil block and then precommit a block id.

A correct process should only do 2 if there are 2f+1 votes for the block id and this not checked but should not be exploitable to cause an equivocation.

Related to #333 