### PR TITLE
Remove signal handlers (closes #331)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,7 +1353,6 @@ dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "signal-hook 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory-dalek 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "signatory-ledger-tm 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ rpassword = { version = "3", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
 sha2 = "0.8"
-signal-hook = "0.1.7"
 signatory = { version = "0.12", features = ["ed25519", "ecdsa"] }
 signatory-dalek = "0.12"
 signatory-secp256k1 = "0.12"

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,10 +17,6 @@ use signatory_dalek::Ed25519Signer;
 use std::{
     panic,
     path::Path,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
     thread::{self, JoinHandle},
     time::Duration,
 };
@@ -42,9 +38,9 @@ pub struct Client {
 
 impl Client {
     /// Spawn a new client, returning a handle so it can be joined
-    pub fn spawn(config: ValidatorConfig, should_term: Arc<AtomicBool>) -> Self {
+    pub fn spawn(config: ValidatorConfig) -> Self {
         Self {
-            handle: thread::spawn(move || client_loop(config, &should_term)),
+            handle: thread::spawn(move || client_loop(config)),
         }
     }
 
@@ -55,7 +51,7 @@ impl Client {
 }
 
 /// Main loop for all clients. Handles reconnecting in the event of an error
-fn client_loop(config: ValidatorConfig, should_term: &Arc<AtomicBool>) {
+fn client_loop(config: ValidatorConfig) {
     let ValidatorConfig {
         addr,
         chain_id,
@@ -65,21 +61,13 @@ fn client_loop(config: ValidatorConfig, should_term: &Arc<AtomicBool>) {
     } = config;
 
     loop {
-        // If we've already received a shutdown signal from outside
-        if should_term.load(Ordering::Relaxed) {
-            info!("[{}@{}] shutdown request received", chain_id, &addr);
-            return;
-        }
-
         let session_result = match addr {
             net::Address::Tcp {
                 peer_id,
                 ref host,
                 port,
             } => match &secret_key {
-                Some(path) => {
-                    tcp_session(chain_id, max_height, peer_id, host, port, path, should_term)
-                }
+                Some(path) => tcp_session(chain_id, max_height, peer_id, host, port, path),
                 None => {
                     error!(
                         "config error: missing field `secret_key` for validator {}",
@@ -88,9 +76,7 @@ fn client_loop(config: ValidatorConfig, should_term: &Arc<AtomicBool>) {
                     return;
                 }
             },
-            net::Address::Unix { ref path } => {
-                unix_session(chain_id, max_height, path, should_term)
-            }
+            net::Address::Unix { ref path } => unix_session(chain_id, max_height, path),
         };
 
         if let Err(e) = session_result {
@@ -103,11 +89,7 @@ fn client_loop(config: ValidatorConfig, should_term: &Arc<AtomicBool>) {
                 return;
             }
         } else {
-            info!("[{}@{}] session closed gracefully", chain_id, &addr);
-            // Indicate to the outer thread it's time to terminate
-            should_term.swap(true, Ordering::Relaxed);
-
-            return;
+            break;
         }
     }
 }
@@ -120,7 +102,6 @@ fn tcp_session(
     host: &str,
     port: u16,
     secret_key_path: &Path,
-    should_term: &Arc<AtomicBool>,
 ) -> Result<(), Error> {
     let secret_key = load_secret_connection_key(secret_key_path)?;
 
@@ -144,7 +125,7 @@ fn tcp_session(
             chain_id, host, port
         );
 
-        session.request_loop(should_term)
+        session.request_loop()
     })
     .unwrap_or_else(|ref e| Err(Error::from_panic(e)))
 }
@@ -154,7 +135,6 @@ fn unix_session(
     chain_id: chain::Id,
     max_height: Option<tendermint::block::Height>,
     socket_path: &Path,
-    should_term: &Arc<AtomicBool>,
 ) -> Result<(), Error> {
     panic::catch_unwind(move || {
         let mut session = Session::connect_unix(chain_id, max_height, socket_path)?;
@@ -165,7 +145,7 @@ fn unix_session(
             socket_path.display()
         );
 
-        session.request_loop(should_term)
+        session.request_loop()
     })
     .unwrap_or_else(|ref e| Err(Error::from_panic(e)))
 }

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,12 +1,8 @@
 //! Start the KMS
 
-use crate::{chain, client::Client, config::ValidatorConfig, prelude::*};
+use crate::{chain, client::Client, prelude::*};
 use abscissa_core::Command;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
-use std::{path::PathBuf, process, thread, time};
+use std::{path::PathBuf, process};
 
 /// The `start` command
 #[derive(Command, Debug, Options)]
@@ -45,25 +41,13 @@ impl Runnable for StartCommand {
             process::exit(1);
         });
 
-        // Should we terminate yet?
-        let should_term = Arc::new(AtomicBool::new(false));
-
         // Spawn the validator client threads
-        let validator_clients = spawn_validator_clients(&config.validator, &should_term);
-        let catch_signals = [signal_hook::SIGTERM, signal_hook::SIGINT];
-
-        // Listen for the relevant signals so we can gracefully shut down
-        for sig in catch_signals.iter() {
-            signal_hook::flag::register(*sig, Arc::clone(&should_term)).unwrap_or_else(|e| {
-                status_err!("couldn't register signal hook: {}", e);
-                process::exit(1);
-            });
-        }
-
-        // Keep checking in on whether or not we need to terminate
-        while !should_term.load(Ordering::Relaxed) {
-            thread::sleep(time::Duration::from_millis(100));
-        }
+        let validator_clients = config
+            .validator
+            .iter()
+            .cloned()
+            .map(Client::spawn)
+            .collect::<Vec<_>>();
 
         // Wait for all of the validator client threads to exit
         info!("Waiting for client threads to stop...");
@@ -71,16 +55,4 @@ impl Runnable for StartCommand {
             client.join();
         }
     }
-}
-
-/// Spawn validator client threads (which provide KMS service to the
-/// validators they connect to)
-fn spawn_validator_clients(
-    config: &[ValidatorConfig],
-    should_term: &Arc<AtomicBool>,
-) -> Vec<Client> {
-    config
-        .iter()
-        .map(|validator| Client::spawn(validator.clone(), Arc::clone(should_term)))
-        .collect()
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -17,10 +17,6 @@ use std::{
     net::TcpStream,
     os::unix::net::UnixStream,
     path::Path,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
     time::Instant,
 };
 use subtle::ConstantTimeEq;
@@ -124,19 +120,13 @@ where
     Connection: Read + Write + Sync + Send,
 {
     /// Main request loop
-    pub fn request_loop(&mut self, should_term: &Arc<AtomicBool>) -> Result<(), Error> {
-        debug!("starting handle request loop ... ");
-        while self.handle_request(should_term)? {}
+    pub fn request_loop(&mut self) -> Result<(), Error> {
+        while self.handle_request()? {}
         Ok(())
     }
 
     /// Handle an incoming request from the validator
-    fn handle_request(&mut self, should_term: &Arc<AtomicBool>) -> Result<bool, Error> {
-        if should_term.load(Ordering::Relaxed) {
-            info!("terminate signal received");
-            return Ok(false);
-        }
-
+    fn handle_request(&mut self) -> Result<bool, Error> {
         let request = Request::read(&mut self.connection)?;
         debug!(
             "[{}:{}] received request: {:?}",


### PR DESCRIPTION
They've been implicated in KMS-related validator outages, and without network timeouts can result in hangs at shutdown.

Furthermore, Abscissa now integrates signal handling if we manage to add network timeouts and want to bring these handlers back:

https://docs.rs/abscissa_core/latest/abscissa_core/signal/index.html

See #331 for full rationale.