### PR TITLE
Refactor Session to remove code duplication

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,22 +5,12 @@
 //! To dance around the fact the KMS isn't actually a service, we refer to it
 //! as a "Key Management System".
 
-use crate::{
-    config::ValidatorConfig,
-    error::{Error, ErrorKind},
-    keyring::SecretKeyEncoding,
-    prelude::*,
-    session::Session,
-};
-use signatory::{ed25519, Decode, Encode, PublicKeyed};
-use signatory_dalek::Ed25519Signer;
+use crate::{config::ValidatorConfig, error::Error, prelude::*, session::Session};
 use std::{
     panic,
-    path::Path,
     thread::{self, JoinHandle},
     time::Duration,
 };
-use tendermint::{chain, net, node, secret_connection};
 
 /// How long to wait after a crash before respawning (in seconds)
 pub const RESPAWN_DELAY: u64 = 1;
@@ -40,7 +30,7 @@ impl Client {
     /// Spawn a new client, returning a handle so it can be joined
     pub fn spawn(config: ValidatorConfig) -> Self {
         Self {
-            handle: thread::spawn(move || client_loop(config)),
+            handle: thread::spawn(move || main_loop(config)),
         }
     }
 
@@ -51,122 +41,21 @@ impl Client {
 }
 
 /// Main loop for all clients. Handles reconnecting in the event of an error
-fn client_loop(config: ValidatorConfig) {
-    let ValidatorConfig {
-        addr,
-        chain_id,
-        reconnect,
-        secret_key,
-        max_height,
-    } = config;
+fn main_loop(config: ValidatorConfig) {
+    while let Err(e) = connect(config.clone()) {
+        error!("[{}@{}] {}", &config.chain_id, &config.addr, e);
 
-    loop {
-        let session_result = match addr {
-            net::Address::Tcp {
-                peer_id,
-                ref host,
-                port,
-            } => match &secret_key {
-                Some(path) => tcp_session(chain_id, max_height, peer_id, host, port, path),
-                None => {
-                    error!(
-                        "config error: missing field `secret_key` for validator {}",
-                        host
-                    );
-                    return;
-                }
-            },
-            net::Address::Unix { ref path } => unix_session(chain_id, max_height, path),
-        };
-
-        if let Err(e) = session_result {
-            error!("[{}@{}] {}", chain_id, addr, e);
-
-            if reconnect {
-                // TODO: configurable respawn delay
-                thread::sleep(Duration::from_secs(RESPAWN_DELAY));
-            } else {
-                return;
-            }
+        if config.reconnect {
+            // TODO: configurable respawn delay
+            thread::sleep(Duration::from_secs(RESPAWN_DELAY));
         } else {
             break;
         }
     }
 }
 
-/// Create a TCP connection to a validator (encrypted with SecretConnection)
-fn tcp_session(
-    chain_id: chain::Id,
-    max_height: Option<tendermint::block::Height>,
-    validator_peer_id: Option<node::Id>,
-    host: &str,
-    port: u16,
-    secret_key_path: &Path,
-) -> Result<(), Error> {
-    let secret_key = load_secret_connection_key(secret_key_path)?;
-
-    let node_public_key =
-        secret_connection::PublicKey::from(Ed25519Signer::from(&secret_key).public_key().unwrap());
-
-    info!("KMS node ID: {}", &node_public_key);
-
-    panic::catch_unwind(move || {
-        let mut session = Session::connect_tcp(
-            chain_id,
-            max_height,
-            validator_peer_id,
-            host,
-            port,
-            &secret_key,
-        )?;
-
-        info!(
-            "[{}@tcp://{}:{}] connected to validator successfully",
-            chain_id, host, port
-        );
-
-        session.request_loop()
-    })
-    .unwrap_or_else(|ref e| Err(Error::from_panic(e)))
-}
-
-/// Create a validator session over a Unix domain socket
-fn unix_session(
-    chain_id: chain::Id,
-    max_height: Option<tendermint::block::Height>,
-    socket_path: &Path,
-) -> Result<(), Error> {
-    panic::catch_unwind(move || {
-        let mut session = Session::connect_unix(chain_id, max_height, socket_path)?;
-
-        info!(
-            "[{}@unix://{}] connected to validator successfully",
-            chain_id,
-            socket_path.display()
-        );
-
-        session.request_loop()
-    })
-    .unwrap_or_else(|ref e| Err(Error::from_panic(e)))
-}
-
-/// Initialize KMS secret connection private key
-fn load_secret_connection_key(path: &Path) -> Result<ed25519::Seed, Error> {
-    if path.exists() {
-        Ok(
-            ed25519::Seed::decode_from_file(path, &SecretKeyEncoding::default()).map_err(|e| {
-                err!(
-                    ErrorKind::ConfigError,
-                    "error loading SecretConnection key from {}: {}",
-                    path.display(),
-                    e
-                )
-            })?,
-        )
-    } else {
-        let seed = ed25519::Seed::generate();
-        seed.encode_to_file(path, &SecretKeyEncoding::default())
-            .map_err(|_| Error::from(ErrorKind::IoError))?;
-        Ok(seed)
-    }
+/// Open a new session and run the session loop
+pub fn connect(config: ValidatorConfig) -> Result<(), Error> {
+    panic::catch_unwind(move || Session::open(config)?.request_loop())
+        .unwrap_or_else(|ref e| Err(Error::from_panic(e)))
 }

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -1,6 +1,11 @@
 //! Validator configuration
 
+use crate::{
+    error::{Error, ErrorKind::*},
+    keyring::SecretKeyEncoding,
+};
 use serde::Deserialize;
+use signatory::{ed25519, Decode, Encode};
 use std::path::PathBuf;
 use tendermint::{chain, net};
 
@@ -23,6 +28,38 @@ pub struct ValidatorConfig {
 
     /// Height at which to stop signing
     pub max_height: Option<tendermint::block::Height>,
+}
+
+impl ValidatorConfig {
+    /// Load the configured secret key from disk
+    pub fn load_secret_key(&self) -> Result<ed25519::Seed, Error> {
+        let secret_key_path = self.secret_key.as_ref().ok_or_else(|| {
+            err!(
+                VerificationError,
+                "config error: no `secret_key` for validator {}",
+                &self.addr
+            )
+        })?;
+
+        let seed = if secret_key_path.exists() {
+            ed25519::Seed::decode_from_file(secret_key_path, &SecretKeyEncoding::default())
+                .map_err(|e| {
+                    err!(
+                        ConfigError,
+                        "error loading Secret Connection key from {}: {}",
+                        secret_key_path.display(),
+                        e
+                    )
+                })?
+        } else {
+            let s = ed25519::Seed::generate();
+            s.encode_to_file(&secret_key_path, &SecretKeyEncoding::default())
+                .map_err(|_| err!(IoError, "couldn't write: {}", secret_key_path.display()))?;
+            s
+        };
+
+        Ok(seed)
+    }
 }
 
 /// Default value for the `ValidatorConfig` reconnect field

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,12 @@
+//! Connections to a validator (TCP or Unix socket)
+
+pub mod tcp;
+pub mod unix;
+
+use std::io;
+
+/// Connections to a validator
+pub trait Connection: io::Read + io::Write + Sync + Send {}
+
+impl<T> Connection for tcp::SecretConnection<T> where T: io::Read + io::Write + Sync + Send {}
+impl<T> Connection for unix::UnixConnection<T> where T: io::Read + io::Write + Sync + Send {}

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -1,0 +1,45 @@
+//! TCP socket connection to a validator
+
+use crate::{
+    error::{Error, ErrorKind::*},
+    prelude::*,
+};
+use signatory::{ed25519, PublicKeyed};
+use signatory_dalek::Ed25519Signer;
+use std::net::TcpStream;
+use subtle::ConstantTimeEq;
+use tendermint::node;
+pub use tendermint::secret_connection::{PublicKey, SecretConnection};
+
+/// Open a TCP socket connection encrypted with SecretConnection
+pub fn open_secret_connection(
+    host: &str,
+    port: u16,
+    peer_id: &Option<node::Id>,
+    secret_key: &ed25519::Seed,
+) -> Result<SecretConnection<TcpStream>, Error> {
+    let signer = Ed25519Signer::from(secret_key);
+    let public_key = PublicKey::from(signer.public_key().map_err(|_| Error::from(InvalidKey))?);
+
+    info!("KMS node ID: {}", &public_key);
+
+    let socket = TcpStream::connect(format!("{}:{}", host, port))?;
+    let connection = SecretConnection::new(socket, &public_key, &signer)?;
+    let actual_peer_id = connection.remote_pubkey().peer_id();
+
+    // TODO(tarcieri): move this into `SecretConnection::new` in `tendermint-rs`?
+    if let Some(expected_peer_id) = peer_id {
+        if expected_peer_id.ct_eq(&actual_peer_id).unwrap_u8() == 0 {
+            fail!(
+                VerificationError,
+                "{}:{}: validator peer ID mismatch! (expected {}, got {})",
+                host,
+                port,
+                expected_peer_id,
+                actual_peer_id
+            );
+        }
+    }
+
+    Ok(connection)
+}

--- a/src/connection/unix.rs
+++ b/src/connection/unix.rs
@@ -1,4 +1,4 @@
-//! Unix domain socket connection
+//! Unix domain socket connection to a validator
 
 use std::io;
 use std::marker::{Send, Sync};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,13 +19,13 @@ pub mod chain;
 pub mod client;
 pub mod commands;
 pub mod config;
+pub mod connection;
 pub mod error;
 pub mod keyring;
 pub mod prelude;
 pub mod rpc;
 pub mod session;
-pub mod unix_connection;
 #[cfg(feature = "yubihsm")]
 pub mod yubihsm;
 
-pub use crate::{application::KmsApplication, unix_connection::UnixConnection};
+pub use crate::application::KmsApplication;


### PR DESCRIPTION
There was a lot of code duplication involved in just juggling and handing off various fields of `ValidatorConfig`.

Instead of that, this makes a copy of the `ValidatorConfig` at the time a given client thread is started, and passes is it through wholesale, storing it in Session.

Finally, `Connection` is made into a proper trait, allowing the generic parameter on `Session` to be removed, instead storing the session in `Box<dyn Connection>`.

This massively simplifies the involved code.