### PR TITLE
v0.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## [0.6.1] (2019-08-05)
+
+- [`abscissa` crate v0.3] ([#338])
+- Refactor `Session` to remove code duplication ([#337])
+- Remove signal handlers ([#336])
+- Double signing - allow some block ID switches ([#335])
+- Consider signed `<nil>` votes to be double signs ([#334])
+
 ## [0.6.0] (2019-07-30)
 
 This release is tested against [tendermint v0.31] and known to be compatible
@@ -136,6 +144,13 @@ section in the Tendermint KMS YubiHSM docs:
 
 - Initial "preview" release
 
+[0.6.1]: https://github.com/tendermint/kms/pull/339
+[`abscissa` crate v0.3]: https://github.com/iqlusioninc/abscissa/pull/127
+[#338]: https://github.com/tendermint/kms/pull/338
+[#337]: https://github.com/tendermint/kms/pull/337
+[#336]: https://github.com/tendermint/kms/pull/336
+[#335]: https://github.com/tendermint/kms/pull/335
+[#334]: https://github.com/tendermint/kms/pull/334
 [0.6.0]: https://github.com/tendermint/kms/pull/329
 [tendermint v0.31]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0316
 [tendermint v0.32]: https://github.com/tendermint/tendermint/blob/master/CHANGELOG.md#v0320

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,7 +1380,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "abscissa_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomicwrites 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.6.0"
+version     = "0.6.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.6.0")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.6.1")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
- [`abscissa` crate v0.3] (#338)
- Refactor `Session` to remove code duplication (#337)
- Remove signal handlers (#336)
- Double signing - allow some block ID switches (#335)
- Consider signed `<nil>` votes to be double signs (#334)

[`abscissa` crate v0.3]: https://github.com/iqlusioninc/abscissa/pull/127