### PR TITLE
chain/state: Avoid panicking in update_consensus_state (fixes #341)

### DIFF
--- a/src/chain/state.rs
+++ b/src/chain/state.rs
@@ -111,8 +111,8 @@ impl State {
                         new_state.height,
                         new_state.round,
                         new_state.step,
-                        self.consensus_state.block_id.as_ref().unwrap(),
-                        new_state.block_id.unwrap()
+                        self.consensus_state.block_id_prefix(),
+                        new_state.block_id_prefix()
                     )
                 }
             }


### PR DESCRIPTION
Previously this codepath assumed the `ConsensusState` `block_ids`are `Some(...)` as the logic above used to explicitly check for it.

This was recently changed to allow them to be `None` (a.k.a. `<nil>`), causing a panic in the event they are `None` (and a `PoisonError`, since they're holding a mutex on the chain state.

This uses a helper method which handles both cases and displays `<nil>` in the event they're `None`.