### PR TITLE
Detect and don't attempt to recover from PoisonError

### DIFF
--- a/src/keyring/ed25519/yubihsm.rs
+++ b/src/keyring/ed25519/yubihsm.rs
@@ -29,13 +29,24 @@ pub fn init(
 
     for config in &yubihsm_configs[0].keys {
         let signer = yubihsm::ed25519::Signer::create(crate::yubihsm::client().clone(), config.key)
-            .map_err(|_| Error::from(InvalidKey))?;
+            .map_err(|_| {
+                err!(
+                    InvalidKey,
+                    "YubiHSM key ID 0x{:04x} is not a valid Ed25519 signing key",
+                    config.key
+                )
+            })?;
 
         // TODO(tarcieri): support for adding account keys into keyrings
         let public_key = TendermintKey::ConsensusKey(
             signer
                 .public_key()
-                .map_err(|_| Error::from(InvalidKey))?
+                .map_err(|_| {
+                    err!(
+                        InvalidKey,
+                        "couldn't get public key for YubiHSM key ID 0x{:04x}"
+                    )
+                })?
                 .into(),
         );
 


### PR DESCRIPTION
[PoisonError](https://doc.rust-lang.org/std/sync/struct.PoisonError.html) indicates that a mutex-guarded data structure is in an inconsistent state because a panic occurred while the mutex was held.

We can't recover from these, so detect when they happen and exit afterward.

Additionally this names each client thread to ease debugging, and adds some better debug logging in several places.