### PR TITLE
Experiment with adding timeouts to tpc socket

### DIFF
--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -6,10 +6,14 @@ use crate::{
 };
 use signatory::{ed25519, PublicKeyed};
 use signatory_dalek::Ed25519Signer;
-use std::net::TcpStream;
+use std::{
+    net::TcpStream,
+    time::Duration,
+};
 use subtle::ConstantTimeEq;
 use tendermint::node;
 pub use tendermint::secret_connection::{PublicKey, SecretConnection};
+
 
 /// Open a TCP socket connection encrypted with SecretConnection
 pub fn open_secret_connection(
@@ -24,6 +28,8 @@ pub fn open_secret_connection(
     info!("KMS node ID: {}", &public_key);
 
     let socket = TcpStream::connect(format!("{}:{}", host, port))?;
+    socket.set_read_timeout(Some(Duration::from_secs(5)))?;
+    socket.set_write_timeout(Some(Duration::from_secs(5)))?;
     let connection = SecretConnection::new(socket, &public_key, &signer)?;
     let actual_peer_id = connection.remote_pubkey().peer_id();
 


### PR DESCRIPTION
Would love to see this merged.

We have tested this and it works as expected, and am running this in production with 2 second timeout on read/writes. 

Even though it seems low, it works nicely since the built-in keepalive on the Tendermint side sends a ping every 100ms and will quickly time out within a few seconds as well:

```
Oct 17 12:44:45 iris[136308]: I[2019-10-17|12:44:45.548] Committed state                              module=state height=2907759 txs=1 appHash=3B2136CE23E208A294E03F7B6820CE65A9DC69F6205FB583016C66E93293D241
Oct 17 12:44:54 iris[136308]: E[2019-10-17|12:44:54.020] Error signing vote                           module=consensus height=2907760 round=0 vote="Vote{54:A2C16A6BDF92 2907760/00/1(Prevote) 29AF0FC2F4BA 000000000000 @ 2019-10-17T10:44:51.020206021Z}" err="remote signer
Oct 17 12:44:57 iris[136308]: E[2019-10-17|12:44:57.021] Ping                                         module=privval err="remote signer timed out"
Oct 17 12:45:00 iris[136308]: E[2019-10-17|12:45:00.021] Reconnecting to remote signer failed         module=privval err="accept tcp [::]:27659: i/o timeout"
Oct 17 12:45:00 iris[136308]: E[2019-10-17|12:45:00.021] Ping                                         module=privval err="remote signer timed out"
```