### PR TITLE
v0.7.0-alpha1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## 0.7.0 (UNRELEASED)
+
+- Upgrade to `signatory` v0.16; `yubihsm` v0.29.0 ([#367])
+- Use the `chacha20poly1305` crate for Secret Connection ([#366])
+- Vendor Secret Connection impl back from `tendermint-rs` ([#365])
+- Add timeout to TCP socket ([#364])
+- Upgrade to `abscissa` v0.4 ([#362])
+- Double signing detection and logging improvements ([#348])
+- Log signing message type during attempted double sign events ([#347])
+
 ## [0.6.3] (2019-08-07)
 
 - Detect and don't attempt to recover from PoisonError ([#345])
@@ -152,6 +162,13 @@ section in the Tendermint KMS YubiHSM docs:
 
 - Initial "preview" release
 
+[#367]: https://github.com/tendermint/kms/pull/367
+[#366]: https://github.com/tendermint/kms/pull/366
+[#365]: https://github.com/tendermint/kms/pull/365
+[#364]: https://github.com/tendermint/kms/pull/364
+[#362]: https://github.com/tendermint/kms/pull/362
+[#348]: https://github.com/tendermint/kms/pull/348
+[#347]: https://github.com/tendermint/kms/pull/347
 [0.6.3]: https://github.com/tendermint/kms/pull/346
 [#345]: https://github.com/tendermint/kms/pull/345
 [0.6.2]: https://github.com/tendermint/kms/pull/343

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.6.3"
+version = "0.7.0-alpha1"
 dependencies = [
  "abscissa_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.6.3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.0-alpha1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.6.3")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.7.0-alpha1")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
- Upgrade to `signatory` v0.16; `yubihsm` v0.29.0 (#367)
- Use the `chacha20poly1305` crate for Secret Connection (#366)
- Vendor Secret Connection impl back from `tendermint-rs` (#365)
- Add timeout to TCP socket (#364)
- Upgrade to `abscissa` v0.4 (#362)
- Double signing detection and logging improvements (#348)
- Log signing message type during attempted double sign events (#347)