### PR TITLE
Use 2018 edition module system for Abscissa macros

### DIFF
--- a/src/chain/registry.rs
+++ b/src/chain/registry.rs
@@ -4,6 +4,7 @@ use super::{Chain, Guard, Id};
 use crate::{
     error::{Error, ErrorKind::*},
     keyring,
+    prelude::*,
 };
 use lazy_static::lazy_static;
 use std::{collections::BTreeMap, sync::RwLock};
@@ -68,7 +69,7 @@ pub struct GlobalRegistry(pub(super) RwLock<Registry>);
 
 impl GlobalRegistry {
     /// Acquire a read-only (concurrent) lock to the internal chain registry
-    pub fn get(&self) -> Guard {
+    pub fn get(&self) -> Guard<'_> {
         // TODO(tarcieri): better handle `PoisonError` here?
         self.0.read().unwrap().into()
     }

--- a/src/chain/state/hook.rs
+++ b/src/chain/state/hook.rs
@@ -3,6 +3,7 @@
 use crate::{
     config::chain::HookConfig,
     error::{Error, ErrorKind::HookError},
+    prelude::*,
 };
 use serde::Deserialize;
 use std::{process::Command, time::Duration};

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -18,7 +18,7 @@ pub use self::yubihsm::YubihsmCommand;
 
 pub use self::{start::StartCommand, version::VersionCommand};
 use crate::config::{KmsConfig, CONFIG_ENV_VAR, CONFIG_FILE_NAME};
-use abscissa_core::{Command, Configurable, Help, Runnable};
+use abscissa_core::{Command, Configurable, Help, Options, Runnable};
 use std::{env, path::PathBuf};
 
 /// Subcommands of the KMS command-line application

--- a/src/commands/ledger.rs
+++ b/src/commands/ledger.rs
@@ -1,7 +1,7 @@
 //! `tmkms ledger` CLI (sub)commands
 
 use crate::{chain, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 use std::{path::PathBuf, process};
 use tendermint::amino_types::{
     vote::{SignVoteRequest, Vote},

--- a/src/commands/softsign.rs
+++ b/src/commands/softsign.rs
@@ -4,7 +4,7 @@ mod import;
 mod keygen;
 
 use self::{import::ImportCommand, keygen::KeygenCommand};
-use abscissa_core::{Command, Help, Runnable};
+use abscissa_core::{Command, Help, Options, Runnable};
 
 /// The `softsign` subcommand
 #[derive(Command, Debug, Options, Runnable)]

--- a/src/commands/softsign/import.rs
+++ b/src/commands/softsign/import.rs
@@ -1,7 +1,7 @@
 //! `tmkms softsign import` command
 
 use crate::{config::provider::softsign::KeyFormat, keyring::SecretKeyEncoding, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 use signatory::{
     ed25519,
     encoding::{Decode, Encode},

--- a/src/commands/softsign/keygen.rs
+++ b/src/commands/softsign/keygen.rs
@@ -1,7 +1,7 @@
 //! `tmkms softsign keygen` subcommand
 
 use crate::{keyring::SecretKeyEncoding, prelude::*};
-use abscissa_core::{Command, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 use signatory::{ed25519, encoding::Encode};
 use std::{path::PathBuf, process};
 

--- a/src/commands/start.rs
+++ b/src/commands/start.rs
@@ -1,7 +1,7 @@
 //! Start the KMS
 
 use crate::{chain, client::Client, prelude::*};
-use abscissa_core::Command;
+use abscissa_core::{Command, Options};
 use std::{path::PathBuf, process};
 
 /// The `start` command

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::never_loop)]
 
 use super::KmsCommand;
-use abscissa_core::{Command, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 
 /// The `version` subcommand
 #[derive(Command, Debug, Default, Options)]

--- a/src/commands/yubihsm.rs
+++ b/src/commands/yubihsm.rs
@@ -6,7 +6,7 @@ mod setup;
 mod test;
 
 pub use self::{detect::DetectCommand, keys::KeysCommand, setup::SetupCommand, test::TestCommand};
-use abscissa_core::{Command, Help, Runnable};
+use abscissa_core::{Command, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// The `yubihsm` subcommand

--- a/src/commands/yubihsm/detect.rs
+++ b/src/commands/yubihsm/detect.rs
@@ -1,6 +1,7 @@
 //! Detect YubiHSM2s connected via USB
 
-use abscissa_core::{Command, Runnable};
+use crate::prelude::*;
+use abscissa_core::{Command, Options, Runnable};
 use std::process;
 use yubihsm::connector::usb::Devices;
 

--- a/src/commands/yubihsm/keys.rs
+++ b/src/commands/yubihsm/keys.rs
@@ -8,7 +8,7 @@ mod list;
 use self::{
     export::ExportCommand, generate::GenerateCommand, import::ImportCommand, list::ListCommand,
 };
-use abscissa_core::{Command, Help, Runnable};
+use abscissa_core::{Command, Help, Options, Runnable};
 use std::path::PathBuf;
 
 /// Default key type to generate

--- a/src/commands/yubihsm/keys/export.rs
+++ b/src/commands/yubihsm/keys/export.rs
@@ -1,7 +1,8 @@
 //! Create encrypted backups of YubiHSM2 keys
 
 use super::*;
-use abscissa_core::{Command, Runnable};
+use crate::prelude::*;
+use abscissa_core::{Command, Options, Runnable};
 use std::{fs::OpenOptions, io::Write, os::unix::fs::OpenOptionsExt, path::PathBuf, process};
 use subtle_encoding::base64;
 

--- a/src/commands/yubihsm/keys/generate.rs
+++ b/src/commands/yubihsm/keys/generate.rs
@@ -1,7 +1,8 @@
 //! Generate a new key within the YubiHSM2
 
 use super::*;
-use abscissa_core::{Command, Runnable};
+use crate::prelude::*;
+use abscissa_core::{Command, Options, Runnable};
 use chrono::{SecondsFormat, Utc};
 use std::{
     fs::OpenOptions,

--- a/src/commands/yubihsm/keys/import.rs
+++ b/src/commands/yubihsm/keys/import.rs
@@ -1,8 +1,8 @@
 //! Import keys either from encrypted backups or existing plaintext keys
 
 use super::*;
-use crate::keyring::SecretKeyEncoding;
-use abscissa_core::{Command, Runnable};
+use crate::{keyring::SecretKeyEncoding, prelude::*};
+use abscissa_core::{Command, Options, Runnable};
 use signatory::{ed25519, encoding::Decode};
 use std::{fs, path::PathBuf, process};
 use subtle_encoding::base64;

--- a/src/commands/yubihsm/keys/list.rs
+++ b/src/commands/yubihsm/keys/list.rs
@@ -1,7 +1,7 @@
 //! List keys inside the YubiHSM2
 
-use crate::{application::app_config, chain, keyring};
-use abscissa_core::{Command, Runnable};
+use crate::{application::app_config, chain, keyring, prelude::*};
+use abscissa_core::{Command, Options, Runnable};
 use std::{collections::BTreeMap as Map, path::PathBuf, process};
 use tendermint::{PublicKey, TendermintKey};
 

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -1,7 +1,7 @@
 //! Set up a new YubiHSM2 or restore from backup
 
 use crate::prelude::*;
-use abscissa_core::{Command, Runnable};
+use abscissa_core::{Command, Options, Runnable};
 use bip39::Mnemonic;
 use chrono::{SecondsFormat, Utc};
 use hkd32::KeyMaterial;

--- a/src/commands/yubihsm/test.rs
+++ b/src/commands/yubihsm/test.rs
@@ -1,6 +1,7 @@
 //! Test the YubiHSM2 is working by performing signatures successively
 
-use abscissa_core::{Command, Runnable};
+use crate::prelude::*;
+use abscissa_core::{Command, Options, Runnable};
 use std::{
     path::PathBuf,
     process, thread,

--- a/src/config/provider/softsign.rs
+++ b/src/config/provider/softsign.rs
@@ -3,6 +3,7 @@
 use crate::{
     chain,
     error::{Error, ErrorKind::ConfigError},
+    prelude::*,
 };
 use serde::Deserialize;
 use std::{

--- a/src/config/provider/yubihsm.rs
+++ b/src/config/provider/yubihsm.rs
@@ -1,6 +1,6 @@
 //! Configuration for the `YubiHSM` backend
 
-use crate::chain;
+use crate::{chain, prelude::*};
 use abscissa_core::secret::{CloneableSecret, DebugSecret, ExposeSecret, Secret};
 use serde::Deserialize;
 use std::{fs, path::PathBuf, process};

--- a/src/config/validator.rs
+++ b/src/config/validator.rs
@@ -3,6 +3,7 @@
 use crate::{
     error::{Error, ErrorKind::*},
     keyring::SecretKeyEncoding,
+    prelude::*,
 };
 use serde::Deserialize;
 use signatory::{

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types
 
-use crate::{chain, prost};
+use crate::{chain, prelude::*, prost};
 use abscissa_core::error::{BoxError, Context};
 use std::{
     any::Any,

--- a/src/keyring/ed25519/ledgertm.rs
+++ b/src/keyring/ed25519/ledgertm.rs
@@ -5,6 +5,7 @@ use crate::{
     config::provider::ledgertm::LedgerTendermintConfig,
     error::{Error, ErrorKind::*},
     keyring::{ed25519::Signer, SigningProvider},
+    prelude::*,
 };
 use signatory::public_key::PublicKeyed;
 use signatory_ledger_tm::Ed25519LedgerTmAppSigner;

--- a/src/keyring/ed25519/signer.rs
+++ b/src/keyring/ed25519/signer.rs
@@ -3,6 +3,7 @@
 use crate::{
     error::{Error, ErrorKind::*},
     keyring::SigningProvider,
+    prelude::*,
 };
 use signatory::{ed25519::Signature, signature};
 use std::sync::Arc;

--- a/src/keyring/ed25519/softsign.rs
+++ b/src/keyring/ed25519/softsign.rs
@@ -8,6 +8,7 @@ use crate::{
     config::provider::softsign::{KeyFormat, SoftsignConfig},
     error::{Error, ErrorKind::*},
     keyring::{SecretKeyEncoding, SigningProvider},
+    prelude::*,
 };
 use signatory::{ed25519, encoding::Decode, public_key::PublicKeyed};
 use signatory_dalek::Ed25519Signer;

--- a/src/keyring/ed25519/yubihsm.rs
+++ b/src/keyring/ed25519/yubihsm.rs
@@ -5,6 +5,7 @@ use crate::{
     config::provider::yubihsm::YubihsmConfig,
     error::{Error, ErrorKind::*},
     keyring::{ed25519::Signer, SigningProvider},
+    prelude::*,
 };
 use signatory::public_key::PublicKeyed;
 use tendermint::TendermintKey;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! Tendermint Key Management System
 
 #![forbid(unsafe_code)]
-#![deny(warnings, missing_docs, unused_qualifications)]
+#![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
 #![doc(html_root_url = "https://docs.rs/tmkms/0.7.0-alpha1")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
@@ -10,8 +10,6 @@ compile_error!(
      yubihsm, ledgertm, softsign (e.g. --features=yubihsm)"
 );
 
-#[macro_use]
-extern crate abscissa_core;
 extern crate prost_amino as prost;
 
 pub mod application;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -7,5 +7,13 @@ pub use crate::application::{app_config, app_reader, app_writer};
 /// Commonly used Abscissa traits
 pub use abscissa_core::{Application, Command, Runnable};
 
-/// Logging macros
-pub use log::{debug, error, info, log, log_enabled, trace, warn};
+/// Error macros
+pub use abscissa_core::{ensure, fail, fatal, format_err};
+
+/// Tracing macros
+pub use abscissa_core::tracing::{debug, error, event, info, span, trace, warn, Level};
+
+/// Status macros
+pub use abscissa_core::{
+    status_attr_err, status_attr_ok, status_err, status_info, status_ok, status_warn,
+};


### PR DESCRIPTION
Eliminates use of `#[macro_use] extern crate abscissa_core` as the method for importing macros, importing them explicitly via the 2018 module system.