### PR TITLE
v0.7.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
-## 0.7.0 (UNRELEASED)
+## [0.7.0] (2019-12-16)
 
+- Upgrade to `abscissa` v0.5 ([#382])
 - Validate chains are registered on startup ([#376])
-- Upgrade to `abscissa` v0.5.0-rc.0 ([#374])
 - Use an initial height of 0 in default chain state ([#373])
 - Upgrade `tendermint-rs` to v0.11 ([#372])
 - Upgrade to `signatory` v0.16; `yubihsm` v0.29.0 ([#367])
@@ -165,8 +165,9 @@ section in the Tendermint KMS YubiHSM docs:
 
 - Initial "preview" release
 
+[0.7.0]: https://github.com/tendermint/kms/pull/383
+[#382]: https://github.com/tendermint/kms/pull/382
 [#376]: https://github.com/tendermint/kms/pull/376
-[#374]: https://github.com/tendermint/kms/pull/374
 [#373]: https://github.com/tendermint/kms/pull/373
 [#372]: https://github.com/tendermint/kms/pull/372
 [#367]: https://github.com/tendermint/kms/pull/367

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.7.0-alpha3"
+version = "0.7.0"
 dependencies = [
  "abscissa_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "atomicwrites 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.7.0-alpha3" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.0" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.7.0-alpha3")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.7.0")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
- Upgrade to `abscissa` v0.5 ([#382])
- Validate chains are registered on startup ([#376])
- Use an initial height of 0 in default chain state ([#373])
- Upgrade `tendermint-rs` to v0.11 ([#372])
- Upgrade to `signatory` v0.16; `yubihsm` v0.29.0 ([#367])
- Use the `chacha20poly1305` crate for Secret Connection ([#366])
- Vendor Secret Connection impl back from `tendermint-rs` ([#365])
- Add timeout to TCP socket ([#364])
- Double signing detection and logging improvements ([#348])
- Log signing message type during attempted double sign events ([#347])

[#382]: https://github.com/tendermint/kms/pull/382
[#376]: https://github.com/tendermint/kms/pull/376
[#373]: https://github.com/tendermint/kms/pull/373
[#372]: https://github.com/tendermint/kms/pull/372
[#367]: https://github.com/tendermint/kms/pull/367
[#366]: https://github.com/tendermint/kms/pull/366
[#365]: https://github.com/tendermint/kms/pull/365
[#364]: https://github.com/tendermint/kms/pull/364
[#348]: https://github.com/tendermint/kms/pull/348
[#347]: https://github.com/tendermint/kms/pull/347