### PR TITLE
rpc.rs: Remove unnecessary parens

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,11 @@ jobs:
           cargo --version
           cargo test --all-features -- --test-threads 1
     - run:
-        name: audit
+        name: security audit
         command: |
+          cargo install --force cargo-audit
           cargo audit --version
-          cargo audit
+          cargo audit --deny-warnings --ignore RUSTSEC-2019-0031
     - run:
         name: validate against test harness
         command: |

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -45,7 +45,7 @@ pub trait TendermintRequest: SignableMsg {
     fn build_response(self, error: Option<RemoteError>) -> Response;
 }
 
-fn compute_prefix(name: &str) -> (Vec<u8>) {
+fn compute_prefix(name: &str) -> Vec<u8> {
     let mut sh = Sha256::default();
     sh.input(name.as_bytes());
     let output = sh.result();


### PR DESCRIPTION
These now generate a warning in Rust 1.40.0