### PR TITLE
Upgrade `x25519-dalek` to v0.6; remove `rand_os`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ dependencies = [
  "ident_case",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "synstructure 0.12.3",
 ]
 
@@ -415,6 +415,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
+dependencies = [
+ "byteorder",
+ "digest 0.8.1",
+ "rand_core 0.5.1",
+ "subtle 2.2.2",
+ "zeroize 1.1.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,7 +448,7 @@ dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
  "strsim",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -446,7 +459,7 @@ checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
 dependencies = [
  "darling_core",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -507,7 +520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
 dependencies = [
  "clear_on_drop",
- "curve25519-dalek",
+ "curve25519-dalek 1.2.3",
  "failure",
  "rand_core 0.3.1",
  "sha2",
@@ -549,7 +562,7 @@ checksum = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "synstructure 0.12.3",
 ]
 
@@ -692,7 +705,7 @@ checksum = "90454ce4de40b7ca6a8968b5ef367bdab48413962588d0d2b1638d60090c35d7"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -1228,29 +1241,29 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "pin-project"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
+checksum = "75fca1c4ff21f60ca2d37b80d72b63dab823a9d19d3cda3a81d18bc03f0ba8c5"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
+checksum = "6544cd4e4ecace61075a6ec78074beeef98d58aa9a3d07d053d993b2946a90d6"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8822eb8bb72452f038ebf6048efa02c3fe22bf83f76519c9583e47fc194a422"
+checksum = "237844750cfbb86f67afe27eee600dfbbcb6188d734139b534cbfbf4f96792ae"
 
 [[package]]
 name = "pin-utils"
@@ -1681,14 +1694,14 @@ checksum = "128f9e303a5a29922045a830221b8f78ec74a5f544944f3d5984f8ec3895ef64"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
+checksum = "eab8f15f15d6c41a154c1b128a22f2dfabe350ef53c40953d84e36155c91192b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1807,7 +1820,7 @@ checksum = "30d0e333aec3605c822b1c7c760f6fa3d28a78d7d762a7b59d21fac4ebbf3680"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "synstructure 0.12.3",
 ]
 
@@ -1930,9 +1943,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4ff033220a41d1a57d8125eab57bf5263783dfdcc18688b1dacc6ce9651ef8"
+checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
@@ -1959,7 +1972,7 @@ checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "unicode-xid 0.2.0",
 ]
 
@@ -2068,7 +2081,7 @@ checksum = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -2129,6 +2142,7 @@ dependencies = [
  "bytes",
  "chacha20poly1305",
  "chrono",
+ "getrandom",
  "gumdrop",
  "hkd32",
  "hkdf",
@@ -2138,7 +2152,6 @@ dependencies = [
  "prost-amino",
  "prost-amino-derive",
  "rand 0.7.3",
- "rand_os",
  "rpassword",
  "serde",
  "serde_json",
@@ -2161,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
+checksum = "c1fc73332507b971a5010664991a441b5ee0de92017f5a0e8b00fd684573045b"
 dependencies = [
  "bytes",
  "fnv",
@@ -2222,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
 dependencies = [
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
 ]
 
 [[package]]
@@ -2285,9 +2298,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
+checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
  "smallvec 1.1.0",
 ]
@@ -2416,7 +2429,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "wasm-bindgen-shared",
 ]
 
@@ -2438,7 +2451,7 @@ checksum = "e85031354f25eaebe78bb7db1c3d86140312a911a106b2e29f9cc440ce3e7668"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2460,7 +2473,7 @@ dependencies = [
  "log",
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "wasm-bindgen-backend",
  "weedle",
 ]
@@ -2542,13 +2555,13 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
+checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "clear_on_drop",
- "curve25519-dalek",
- "rand_core 0.3.1",
+ "curve25519-dalek 2.0.0",
+ "rand_core 0.5.1",
+ "zeroize 1.1.0",
 ]
 
 [[package]]
@@ -2629,6 +2642,6 @@ checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
  "proc-macro2 1.0.8",
  "quote 1.0.2",
- "syn 1.0.13",
+ "syn 1.0.14",
  "synstructure 0.12.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ byteorder = "1.2"
 bytes = "0.5"
 chacha20poly1305 = "0.3"
 chrono = "0.4"
+getrandom = "0.1"
 gumdrop = "0.7"
 hkd32 = { version = "0.3", default-features = false, features = ["mnemonic"] }
 hkdf = "0.7"
@@ -28,7 +29,7 @@ lazy_static = "1"
 log = "0.4"
 prost-amino = "0.5"
 prost-amino-derive = "0.5"
-rand_os = "0.1"
+rand = "0.7"
 rpassword = { version = "3", optional = true }
 serde = { version = "1", features = ["serde_derive"] }
 serde_json = "1"
@@ -43,13 +44,12 @@ tendermint = "0.12.0-rc0"
 thiserror = "1"
 tiny-bip39 = "0.6"
 wait-timeout = "0.2"
-x25519-dalek = "0.5"
+x25519-dalek = "0.6"
 yubihsm = { version = "0.31", features = ["setup", "usb"], optional = true }
 zeroize = "1"
 
 [dev-dependencies]
 tempfile = "3"
-rand = "0.7"
 
 [dev-dependencies.abscissa_core]
 version = "0.5"

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -4,9 +4,9 @@ use crate::prelude::*;
 use abscissa_core::{Command, Options, Runnable};
 use bip39::Mnemonic;
 use chrono::{SecondsFormat, Utc};
+use getrandom::getrandom;
 use hkd32::KeyMaterial;
 use hkdf::Hkdf;
-use rand_os::{rand_core::RngCore, OsRng};
 use sha2::Sha512;
 use std::{
     fs::File,
@@ -253,7 +253,7 @@ fn generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector: &Connector) -> Mnemo
     // for a total of 512-bits IKM. This ensures we still get 256-bits
     // of good IKM even in the event one of the RNGs fails.
     ikm.extend_from_slice(&[0u8; KEY_SIZE]);
-    OsRng::new().unwrap().fill_bytes(&mut ikm[KEY_SIZE..]);
+    getrandom(&mut ikm[KEY_SIZE..]).expect("RNG failure!");
 
     let kdf = Hkdf::<Sha512>::extract(None, &ikm);
 

--- a/src/connection/secret_connection.rs
+++ b/src/connection/secret_connection.rs
@@ -14,7 +14,6 @@ use chacha20poly1305::{
     ChaCha20Poly1305,
 };
 use prost::{encoding::encode_varint, Message};
-use rand_os::OsRng;
 use signatory::{
     ed25519,
     signature::{Signature, Signer, Verifier},
@@ -288,7 +287,7 @@ where
 
 /// Returns pubkey, private key
 fn gen_eph_keys() -> (EphemeralPublic, EphemeralSecret) {
-    let mut local_csprng = OsRng::new().unwrap();
+    let mut local_csprng = rand::thread_rng();
     let local_privkey = EphemeralSecret::new(&mut local_csprng);
     let local_pubkey = EphemeralPublic::from(&local_privkey);
     (local_pubkey, local_privkey)


### PR DESCRIPTION
The `rand_os` crate is deprecated and uses an out-of-date `rand_core` dependency, which was previously blocking the `x25519-dalek` upgrade.

This replaces it with `rand` v0.7 and `rand::thread_rng()`, a `CryptoRng` (ensured by dalek's trait bounds) seeded by the OS RNG.

For producing the YubiHSM master secret used during setup, the `getrandom` crate is used directly, since this is guaranteed to be a direct interface to the OS RNG (it also pulls randomness from the YubiHSM itself).