### PR TITLE
Replace `tiny-bip39` with the equivalent `hkd32` functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
  "generational-arena",
  "gumdrop",
  "libc",
- "once_cell 1.3.1",
+ "once_cell",
  "regex",
  "secrecy",
  "semver",
@@ -734,16 +734,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60bf12c625ed5e96f81609ae4377c34e9fa3e4d1fada392404322daeace511ab"
 
 [[package]]
-name = "hashbrown"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bae29b6653b3412c2e71e9d486db9f9df5d701941d86683005efb9f2d28e3da"
-dependencies = [
- "byteorder",
- "scopeguard",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,15 +1001,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lock_api"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1154,15 +1135,6 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
-dependencies = [
- "parking_lot",
-]
-
-[[package]]
-name = "once_cell"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
@@ -1198,29 +1170,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aee0d9bdeedaea6cdd47f9281a9f8e1037d3037088b70e2af13c64ce65608ec"
 dependencies = [
  "elliptic-curve",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
-dependencies = [
- "libc",
- "rand 0.6.5",
- "rustc_version",
- "smallvec 0.6.13",
- "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1620,25 +1569,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-
-[[package]]
-name = "scopeguard"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 
 [[package]]
 name = "secp256k1"
@@ -2104,21 +2038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-bip39"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1c5676413eaeb1ea35300a0224416f57abc3bd251657e0fafc12c47ff98c060"
-dependencies = [
- "failure",
- "hashbrown",
- "hmac",
- "once_cell 0.1.8",
- "pbkdf2",
- "rand 0.6.5",
- "sha2",
-]
-
-[[package]]
 name = "tiny_http"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,7 +2066,7 @@ dependencies = [
  "hkdf",
  "hmac",
  "log",
- "once_cell 1.3.1",
+ "once_cell",
  "prost-amino",
  "prost-amino-derive",
  "rand 0.7.3",
@@ -2164,7 +2083,6 @@ dependencies = [
  "tempfile",
  "tendermint",
  "thiserror",
- "tiny-bip39",
  "wait-timeout",
  "x25519-dalek",
  "yubihsm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,6 @@ subtle = "2"
 subtle-encoding = { version = "0.4", features = ["bech32-preview"] }
 tendermint = "= 0.12.0-rc0"
 thiserror = "1"
-tiny-bip39 = "0.6"
 wait-timeout = "0.2"
 x25519-dalek = "0.6"
 yubihsm = { version = "0.31", features = ["setup", "usb"], optional = true }

--- a/src/commands/yubihsm/setup.rs
+++ b/src/commands/yubihsm/setup.rs
@@ -2,17 +2,16 @@
 
 use crate::prelude::*;
 use abscissa_core::{Command, Options, Runnable};
-use bip39::Mnemonic;
 use chrono::{SecondsFormat, Utc};
 use getrandom::getrandom;
-use hkd32::KeyMaterial;
+use hkd32::{mnemonic, KeyMaterial};
 use hkdf::Hkdf;
 use sha2::Sha512;
 use std::{
     fs::File,
     io::{self, Write},
     path::PathBuf,
-    process,
+    process::exit,
 };
 use subtle_encoding::{bech32::Bech32, hex};
 use yubihsm::{
@@ -25,14 +24,14 @@ use zeroize::{Zeroize, Zeroizing};
 /// Domain separation string used as "info" for HKDF
 const HKDF_MNEMONIC_INFO: &[u8] = b"yubihsm setup BIP39 derivation";
 
-/// Language used when generating the Mnemonic phrase
-const BIP39_LANGUAGE: bip39::Language = bip39::Language::English;
+/// Language used when generating the [`mnemonic::Phrase`]
+const BIP39_LANGUAGE: mnemonic::Language = mnemonic::Language::English;
 
 /// Domain separation for derivation hierarchy versions (ala BIP43's "purpose" field)
 const DERIVATION_VERSION: &[u8] = b"1";
 
 /// Key size to use for generating passwords and wrap keys (256-bits).
-/// This results in a 24-word BIP39 `Mnemonic` phrase.
+/// This results in a 24-word BIP39 [`mnemonic::Phrase`].
 const KEY_SIZE: usize = 32;
 
 /// Role names
@@ -146,7 +145,7 @@ impl Runnable for SetupCommand {
         println!("- wrapkey 0x0001 [primary]:   {}", wrapkey_hex.as_str());
 
         if self.print_only {
-            process::exit(0);
+            exit(0);
         }
 
         prompt_for_user_approval("Are you SURE you want erase and reinitialize this HSM?");
@@ -185,7 +184,7 @@ impl Runnable for SetupCommand {
 }
 
 /// Read the mnemonic phrase from STDIN
-fn read_mnemonic_from_stdin(prompt: &str) -> Mnemonic {
+fn read_mnemonic_from_stdin(prompt: &str) -> mnemonic::Phrase {
     print!("{}", prompt);
     io::stdout().flush().unwrap();
 
@@ -198,9 +197,9 @@ fn read_mnemonic_from_stdin(prompt: &str) -> Mnemonic {
     let input_phrase = input_words.join(" ");
     input_string.zeroize();
 
-    let result = Mnemonic::from_phrase(input_phrase, BIP39_LANGUAGE).unwrap_or_else(|e| {
-        eprintln!("*** ERROR: Couldn't decode mnemonic: {}", e);
-        process::exit(1);
+    let result = mnemonic::Phrase::new(input_phrase, BIP39_LANGUAGE).unwrap_or_else(|_| {
+        eprintln!("*** ERROR: Couldn't decode mnemonic");
+        exit(1);
     });
 
     println!("\nMnemonic phrase decoded/checksummed successfully!\n");
@@ -209,7 +208,7 @@ fn read_mnemonic_from_stdin(prompt: &str) -> Mnemonic {
 }
 
 /// Display the mnemonic as two groups of 12 words
-fn print_mnemonic(mnemonic: &Mnemonic) {
+fn print_mnemonic(mnemonic: &mnemonic::Phrase) {
     let words: Vec<&str> = mnemonic.phrase().split(' ').collect();
     let words_len = words.len();
 
@@ -241,7 +240,7 @@ fn get_hsm_client(hsm_connector: &Connector) -> yubihsm::Client {
 /// function (HKDF) in order to derive the recovery passphrase, which ideally
 /// ensures that the passphrase will be securely random so long as at least
 /// one of the two inputs is secure.
-fn generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector: &Connector) -> Mnemonic {
+fn generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector: &Connector) -> mnemonic::Phrase {
     let hsm_client = get_hsm_client(hsm_connector);
 
     // Obtain half of the IKM from the YubiHSM (256-bits)
@@ -262,14 +261,14 @@ fn generate_mnemonic_from_hsm_and_os_csprngs(hsm_connector: &Connector) -> Mnemo
     kdf.expand(HKDF_MNEMONIC_INFO, &mut okm).unwrap();
     ikm.zeroize();
 
-    let result = Mnemonic::from_entropy(&okm, BIP39_LANGUAGE).unwrap();
+    let result = mnemonic::Phrase::from_entropy(okm, BIP39_LANGUAGE);
     okm.zeroize();
 
     result
 }
 
-/// Derive the default roles form the given BIP39 `Mnemonic`
-fn derive_roles_from_mnemonic(mnemonic: &Mnemonic) -> Vec<Role> {
+/// Derive the default roles form the given BIP39 `mnemonic::Phrase`
+fn derive_roles_from_mnemonic(mnemonic: &mnemonic::Phrase) -> Vec<Role> {
     let admin_role = derive_admin_role_from_mnemonic(mnemonic);
 
     // operator
@@ -318,10 +317,10 @@ fn derive_roles_from_mnemonic(mnemonic: &Mnemonic) -> Vec<Role> {
 ///
 /// The admin role is somewhat different from the others and confers total
 /// authority over the HSM device.
-fn derive_admin_role_from_mnemonic(mnemonic: &Mnemonic) -> Role {
+fn derive_admin_role_from_mnemonic(mnemonic: &mnemonic::Phrase) -> Role {
     let admin_credentials = Credentials::new(
         1,
-        authentication::Key::derive_from_password(mnemonic.as_ref().as_bytes()),
+        authentication::Key::derive_from_password(mnemonic.phrase().as_bytes()),
     );
 
     Role::new(admin_credentials)
@@ -332,7 +331,11 @@ fn derive_admin_role_from_mnemonic(mnemonic: &Mnemonic) -> Role {
 }
 
 /// Derive the initial settings for a role from the given mnemonic
-fn derive_role_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id, role_name: &str) -> Role {
+fn derive_role_from_mnemonic(
+    mnemonic: &mnemonic::Phrase,
+    key_id: object::Id,
+    role_name: &str,
+) -> Role {
     let role_password = RolePassword::derive_from_mnemonic(&mnemonic, role_name);
 
     let role_credentials = Credentials::new(
@@ -343,13 +346,13 @@ fn derive_role_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id, role_name:
     Role::new(role_credentials).authentication_key_label(create_object_label(role_name))
 }
 
-/// Passwords for a given role, derived from a BIP39 `Mnemonic`.
+/// Passwords for a given role, derived from a BIP39 `mnemonic::Phrase`.
 /// These are serialized as Bech32 for compactness.
 struct RolePassword(String);
 
 impl RolePassword {
-    /// Derive a role password from the given BIP39 `Mnemonic`
-    pub fn derive_from_mnemonic(mnemonic: &Mnemonic, role_name: &str) -> Self {
+    /// Derive a role password from the given BIP39 `mnemonic::Phrase`
+    pub fn derive_from_mnemonic(mnemonic: &mnemonic::Phrase, role_name: &str) -> Self {
         let mut secret_key =
             derive_secret_from_mnemonic(mnemonic, &[b"role", role_name.as_bytes()]);
 
@@ -386,8 +389,8 @@ impl Drop for RolePassword {
     }
 }
 
-/// Derive a wrap key from the given BIP39 `Mnemonic`
-fn derive_wrap_key_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id) -> wrap::Key {
+/// Derive a wrap key from the given BIP39 `mnemonic::Phrase`
+fn derive_wrap_key_from_mnemonic(mnemonic: &mnemonic::Phrase, key_id: object::Id) -> wrap::Key {
     // Capabilities given to the initial wrap key:
     // wrap/unwrap both data and objects
     let wrap_key_capabilities = Capability::EXPORT_WRAPPED
@@ -410,7 +413,7 @@ fn derive_wrap_key_from_mnemonic(mnemonic: &Mnemonic, key_id: object::Id) -> wra
     let wrap_key_label = create_object_label("primary");
 
     // Includes the key ID in the derivation path, which allows us to derive
-    // other wrap keys from the same seed `Mnemonic` phrase in the event one
+    // other wrap keys from the same seed `mnemonic::Phrase` phrase in the event one
     // has been compromised.
     wrap::Key::from_bytes(
         key_id,
@@ -429,10 +432,10 @@ fn serialize_key_id(key_id: object::Id) -> String {
     format!("0x{:04x}", key_id)
 }
 
-/// Derive secrets from the given BIP39 `Mnemonic` ala a BIP32 (hardened)
+/// Derive secrets from the given BIP39 `mnemonic::Phrase` ala a BIP32 (hardened)
 /// derivation hierarchy.
 // TODO(tarcieri): refactor `path` to use `impl AsRef<hkd32::Path>`
-fn derive_secret_from_mnemonic(mnemonic: &Mnemonic, path: &[&[u8]]) -> KeyMaterial {
+fn derive_secret_from_mnemonic(mnemonic: &mnemonic::Phrase, path: &[&[u8]]) -> KeyMaterial {
     assert!(!path.is_empty(), "cannot derive keys for the root path");
 
     debug!(
@@ -484,7 +487,7 @@ fn prompt_for_user_approval(prompt: &str) {
 
     if choice != "y" && choice != "Y" {
         println!("Aborting");
-        process::exit(1);
+        exit(1);
     }
 }
 
@@ -493,7 +496,7 @@ fn hsm_error(e: &dyn std::error::Error) -> ! {
     status_err!("HSM error: {}", e);
 
     // TODO: handle exits via abscissa
-    process::exit(1);
+    exit(1);
 }
 
 #[cfg(test)]
@@ -501,30 +504,30 @@ mod tests {
     use super::*;
 
     /// "HKD32" test vector derivation key
-    const TEST_KEY: &[u8] = &[
+    const TEST_KEY: [u8; KEY_SIZE] = [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30, 31,
     ];
 
-    /// BIP39 Mnemonic phrase corresponding to the `TEST_KEY`
+    /// BIP39 mnemonic::Phrase phrase corresponding to the `TEST_KEY`
     const TEST_BIP39_PHRASE: &str =
         "abandon amount liar amount expire adjust cage candy arch gather drum bullet \
          absurd math era live bid rhythm alien crouch range attend journey unaware";
 
-    /// Test vector `Mnemonic`
-    fn test_mnemonic() -> Mnemonic {
-        Mnemonic::from_entropy(TEST_KEY, BIP39_LANGUAGE).unwrap()
+    /// Test vector `mnemonic::Phrase`
+    fn test_mnemonic() -> mnemonic::Phrase {
+        mnemonic::Phrase::from_entropy(TEST_KEY, BIP39_LANGUAGE)
     }
 
     #[test]
     fn derive_test_key_from_test_mnemonic() {
-        assert_eq!(test_mnemonic().entropy(), TEST_KEY);
+        assert_eq!(test_mnemonic().entropy(), &TEST_KEY);
     }
 
     #[test]
     fn derive_test_key_from_test_bip39_phrase() {
-        let mnemonic = Mnemonic::from_phrase(TEST_BIP39_PHRASE, BIP39_LANGUAGE).unwrap();
-        assert_eq!(mnemonic.entropy(), TEST_KEY);
+        let mnemonic = mnemonic::Phrase::new(TEST_BIP39_PHRASE, BIP39_LANGUAGE).unwrap();
+        assert_eq!(mnemonic.entropy(), &TEST_KEY);
     }
 
     struct DeriveVector<'a> {


### PR DESCRIPTION
The `tiny-bip39` crate is an unmaintained fork of the unmaintained `bip39` crate.

As such, it duplicates functionality in the `hkd32` crate, which can be used to straightforwardly replace it.

The existing test vectors cover the derivation paths to ensure that they are still compatible.