### PR TITLE
Remove explicit dependency on the `log` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2064,7 +2064,6 @@ dependencies = [
  "hkd32",
  "hkdf",
  "hmac",
- "log",
  "once_cell",
  "prost-amino",
  "prost-amino-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ gumdrop = "0.7"
 hkd32 = { version = "0.3", default-features = false, features = ["mnemonic"] }
 hkdf = "0.7"
 hmac = "0.7"
-log = "0.4"
 once_cell = "1.3"
 prost-amino = "0.5"
 prost-amino-derive = "0.5"

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3,8 +3,8 @@
 extern crate prost_amino as prost;
 
 use crate::prost::Message;
+use abscissa_core::prelude::warn;
 use chrono::{DateTime, Utc};
-use log::warn;
 use rand::Rng;
 use signatory::{
     ed25519,


### PR DESCRIPTION
We now use `tracing` behind the scenes