### PR TITLE
Remove remaining non-namespaced references to `prost`

### DIFF
--- a/src/connection/secret_connection.rs
+++ b/src/connection/secret_connection.rs
@@ -12,7 +12,7 @@ use chacha20poly1305::{
     aead::{generic_array::GenericArray, Aead, NewAead},
     ChaCha20Poly1305,
 };
-use prost::{encoding::encode_varint, Message};
+use prost_amino::{encoding::encode_varint, Message};
 use signatory::{
     ed25519,
     signature::{Signature, Signer, Verifier},

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Error types
 
-use crate::{chain, prelude::*, prost};
+use crate::{chain, prelude::*};
 use abscissa_core::error::{BoxError, Context};
 use std::{
     any::Any,
@@ -155,14 +155,14 @@ impl std::error::Error for Error {
     }
 }
 
-impl From<prost::DecodeError> for Error {
-    fn from(other: prost::DecodeError) -> Self {
+impl From<prost_amino::DecodeError> for Error {
+    fn from(other: prost_amino::DecodeError) -> Self {
         ErrorKind::ProtocolError.context(other).into()
     }
 }
 
-impl From<prost::EncodeError> for Error {
-    fn from(other: prost::EncodeError) -> Self {
+impl From<prost_amino::EncodeError> for Error {
+    fn from(other: prost_amino::EncodeError) -> Self {
         ErrorKind::ProtocolError.context(other).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@ compile_error!(
      yubihsm, ledgertm, softsign (e.g. --features=yubihsm)"
 );
 
-extern crate prost_amino as prost;
-
 pub mod application;
 pub mod chain;
 pub mod client;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -3,12 +3,12 @@
 // TODO: docs for everything
 #![allow(missing_docs)]
 
-use crate::{
-    prost::encoding::{decode_varint, encoded_len_varint},
-    prost::Message,
-};
 use bytes::Bytes;
 use once_cell::sync::Lazy;
+use prost_amino::{
+    encoding::{decode_varint, encoded_len_varint},
+    Message,
+};
 use sha2::{Digest, Sha256};
 use std::io::{self, Error, ErrorKind, Read};
 use tendermint::amino_types::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,10 +1,8 @@
 //! KMS integration test
 
-extern crate prost_amino as prost;
-
-use crate::prost::Message;
 use abscissa_core::prelude::warn;
 use chrono::{DateTime, Utc};
+use prost_amino::Message;
 use rand::Rng;
 use signatory::{
     ed25519,
@@ -298,13 +296,13 @@ fn test_key() -> (ed25519::PublicKey, Ed25519Signer) {
 }
 
 /// Extract the actual length of an amino message
-pub fn extract_actual_len(buf: &[u8]) -> Result<u64, prost::DecodeError> {
+pub fn extract_actual_len(buf: &[u8]) -> Result<u64, prost_amino::DecodeError> {
     let mut buff = Cursor::new(buf);
-    let actual_len = prost::encoding::decode_varint(&mut buff)?;
+    let actual_len = prost_amino::encoding::decode_varint(&mut buff)?;
     if actual_len == 0 {
         return Ok(1);
     }
-    Ok(actual_len + (prost::encoding::encoded_len_varint(actual_len) as u64))
+    Ok(actual_len + (prost_amino::encoding::encoded_len_varint(actual_len) as u64))
 }
 
 #[test]


### PR DESCRIPTION
...renaming them all to `prost_amino`.

This should allow us to use `prost` proper with the KMS to do proper Protobuf encoding/decoding.