### PR TITLE
v0.7.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+## [0.7.1] (2020-01-23)
+
+- Remove explicit dependency on the `log` crate ([#398])
+- Remove `byteorder` dependency ([#397])
+- Replace `tiny-bip39` with the equivalent `hkd32` functionality ([#396])
+- Replace `lazy_static` with `once_cell` ([#395])
+- Update `rpassword` requirement from 3.0 to 4.0 ([#394])
+- Upgrade `x25519-dalek` to v0.6; remove `rand_os` ([#393])
+- Remove `failure` ([#392])
+- Update to `tendermint-rs` 0.12.0-rc0; `prost-amino` v0.5; `signatory v0.18` ([#391], [#399])
+
 ## [0.7.0] (2019-12-16)
 
 - Upgrade to `abscissa` v0.5 ([#382])
@@ -165,6 +176,16 @@ section in the Tendermint KMS YubiHSM docs:
 
 - Initial "preview" release
 
+[0.7.1]: https://github.com/tendermint/kms/pull/400
+[#399]: https://github.com/tendermint/kms/pull/399
+[#398]: https://github.com/tendermint/kms/pull/398
+[#397]: https://github.com/tendermint/kms/pull/397
+[#396]: https://github.com/tendermint/kms/pull/396
+[#395]: https://github.com/tendermint/kms/pull/395
+[#394]: https://github.com/tendermint/kms/pull/394
+[#393]: https://github.com/tendermint/kms/pull/393
+[#392]: https://github.com/tendermint/kms/pull/392
+[#391]: https://github.com/tendermint/kms/pull/391
 [0.7.0]: https://github.com/tendermint/kms/pull/383
 [#382]: https://github.com/tendermint/kms/pull/382
 [#376]: https://github.com/tendermint/kms/pull/376

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "tmkms"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "abscissa_core",
  "atomicwrites",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name        = "tmkms"
 description = "Tendermint Key Management System"
-version     = "0.7.0" # Also update html_root_url in lib.rs when bumping this
+version     = "0.7.1" # Also update html_root_url in lib.rs when bumping this
 authors     = ["Tony Arcieri <tony@iqlusion.io>", "Ismail Khoffi <Ismail.Khoffi@gmail.com>"]
 license     = "Apache-2.0"
 homepage    = "https://github.com/tendermint/kms/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![forbid(unsafe_code)]
 #![deny(warnings, rust_2018_idioms, missing_docs, unused_qualifications)]
-#![doc(html_root_url = "https://docs.rs/tmkms/0.7.0")]
+#![doc(html_root_url = "https://docs.rs/tmkms/0.7.1")]
 
 #[cfg(not(any(feature = "softsign", feature = "yubihsm", feature = "ledgertm")))]
 compile_error!(


### PR DESCRIPTION
- Remove explicit dependency on the `log` crate (#398)
- Remove `byteorder` dependency (#397)
- Replace `tiny-bip39` with the equivalent `hkd32` functionality (#396)
- Replace `lazy_static` with `once_cell` (#395)
- Update `rpassword` requirement from 3.0 to 4.0 (#394)
- Upgrade `x25519-dalek` to v0.6; remove `rand_os` (#393)
- Remove `failure` (#392)
- Update to `tendermint-rs` 0.12.0-rc0; `prost-amino` v0.5; `signatory v0.18` (#391, #399)